### PR TITLE
Removes CCD and image processing keyword sections from level 2 data

### DIFF
--- a/punchbowl/data/Level2.yaml
+++ b/punchbowl/data/Level2.yaml
@@ -18,7 +18,6 @@ Level:
             CDELT1: 1.0
             CRPIX1A: 0.0
             CDELT1A: 1.0
-    Calibration Data:
     Image Statistics and Properties:
     Solar Reference Data:
     Spacecraft Location & Environment:


### PR DESCRIPTION
## PR summary

Removes CCD and image processing keyword sections from level 2 data

## Todos

- [x] Do we need the Calibration Data section with calibration file references in level 2 data?
```
8,section,COMMENT,Calibration Data,,str,TRUE,TRUE, Calibration Data
8,keyword,CALCF,,quartic fit filename,str,TRUE,TRUE,
8,keyword,CALVI,,vignetting filename,str,TRUE,TRUE,
8,keyword,CALPSF,,PSF filename,str,TRUE,TRUE,
8,keyword,CALPM,,bad pixel map filename (TBC),str,TRUE,TRUE,
8,keyword,CALSL,,stray light model filename(TBC),str,TRUE,TRUE,
```
- [ ] Any other changes that @mwest007 identified?

## Related Issues

This should close out #193 
