### PR TITLE
Faster star subtraction

### DIFF
--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -144,23 +144,23 @@ def subtract_starfield_background_task(data_object: NDCube,
         data_wcs = calculate_celestial_wcs_from_helio(data_object.wcs.celestial,
                                                       data_object.meta.astropy_time,
                                                       data_object.data.shape[-2:])
-        for i in range(3):
-            starfield_model = Starfield(star_datacube[i], star_datacube.wcs.celestial)
-            starfield_subtracted_data = starfield_model.subtract_from_image(
-                NDCube(data=data_object.data[i],
-                       wcs=data_wcs,
-                       meta=data_object.meta),
-                processor=PUNCHImageProcessor(i))
+        starfield_model = Starfield(star_datacube.data, star_datacube.wcs.celestial)
 
-            starfield_subtracted_uncertainty = starfield_model.subtract_from_image(
-                NDCube(data=data_object.uncertainty.array[i],
-                       wcs=data_wcs,
-                       meta=data_object.meta),
-                processor=PUNCHImageProcessor(i))
+        starfield_subtracted_data = starfield_model.subtract_from_image(
+            NDCube(data=data_object.data,
+                   wcs=data_wcs,
+                   meta=data_object.meta),
+            processor=PUNCHImageProcessor(0))
 
-            data_object.data[i, ...] = starfield_subtracted_data.subtracted
-            data_object.uncertainty.array[i, ...] = starfield_subtracted_uncertainty.subtracted
-            data_object.meta.history.add_now("LEVEL3-subtract_starfield_background", "subtracted starfield background")
+        starfield_subtracted_uncertainty = starfield_model.subtract_from_image(
+            NDCube(data=data_object.uncertainty.array,
+                   wcs=data_wcs,
+                   meta=data_object.meta),
+            processor=PUNCHImageProcessor(0))
+
+        data_object.data[...] = starfield_subtracted_data.subtracted
+        data_object.uncertainty.array[...] -= starfield_subtracted_uncertainty.subtracted
+        data_object.meta.history.add_now("LEVEL3-subtract_starfield_background", "subtracted starfield background")
         output = data_object
     logger.info("subtract_f_corona_background finished")
 

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -143,7 +143,7 @@ def subtract_starfield_background_task(data_object: NDCube,
         star_datacube = load_ndcube_from_fits(starfield_background_path)
         data_wcs = calculate_celestial_wcs_from_helio(data_object.wcs.celestial,
                                                       data_object.meta.astropy_time,
-                                                      (4096, 4096))
+                                                      data_object.data.shape[-2:])
         for i in range(3):
             starfield_model = Starfield(star_datacube[i], star_datacube.wcs.celestial)
             starfield_subtracted_data = starfield_model.subtract_from_image(

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -145,7 +145,7 @@ def subtract_starfield_background_task(data_object: NDCube,
                                                       data_object.meta.astropy_time,
                                                       (4096, 4096))
         for i in range(3):
-            starfield_model = Starfield(star_datacube[i], star_datacube.wcs)
+            starfield_model = Starfield(star_datacube[i], star_datacube.wcs.celestial)
             starfield_subtracted_data = starfield_model.subtract_from_image(
                 NDCube(data=data_object.data[i],
                        wcs=data_wcs,


### PR DESCRIPTION
## PR summary

Step 1 of speeding up starfield subtraction. This avoids looping over polarization components.

~The results of the before and after aren't exactly equal, but they're `np.allclose`, and I don't know why yet. The reprojected starfield samples appear to be `np.array_equal`, but the blurred input data is only `np.allclsoe`.~

I found the bug in my test setup. This PR produces bit-for-bit identical outputs.

Runtime appears to be 26 minutes before and 10 minutes after.

## Todos

- [x] Figure that out

## Test plan

It seems to work on my machine

## Breaking changes

None
