### PR TITLE
When generating WCSes, set NAXIS/array_shape/etc.

### DIFF
--- a/punchbowl/data/wcs.py
+++ b/punchbowl/data/wcs.py
@@ -75,6 +75,7 @@ def calculate_helio_wcs_from_celestial(wcs_celestial: WCS,
 
     if is_3d:
         wcs_helio = astropy.wcs.utils.add_stokes_axis_to_wcs(wcs_helio, 2)
+    wcs_helio.array_shape = data_shape
 
     return wcs_helio, p_angle
 
@@ -305,6 +306,7 @@ def calculate_celestial_wcs_from_helio(wcs_helio: WCS, date_obs: datetime, data_
 
     if is_3d:
         wcs_celestial = add_stokes_axis_to_wcs(wcs_celestial, 2)
+    wcs_celestial.array_shape = data_shape
 
     return wcs_celestial
 


### PR DESCRIPTION
## PR summary

Ran into this when testing a `remove_starfield` speedup---generated WCSes don't have their NAXISN keywords set, and therefore don't have `pixel_shape` or `array_shape`.  On the `remove_starfield` side that can and should and now is handled. But this seems like a might-as-well-have on the `punchbowl` side.