### PR TITLE
Unpack uncertainties faster

### DIFF
--- a/punchbowl/data/io.py
+++ b/punchbowl/data/io.py
@@ -114,7 +114,10 @@ def _pack_uncertainty(cube: NDCube) -> np.ndarray:
 
 def _unpack_uncertainty(uncertainty_array: np.ndarray, data_array: np.ndarray) -> np.ndarray:
     """Uncompress the uncertainty when reading from a file."""
-    return (1/uncertainty_array) * data_array
+    # This is (1/uncertainty_array) * data_array, but this way we save time on memory allocation
+    np.divide(1, uncertainty_array, out=uncertainty_array)
+    np.multiply(data_array, uncertainty_array, out=uncertainty_array)
+    return uncertainty_array
 
 
 def _update_statistics(cube: NDCube) -> None:

--- a/punchbowl/level3/tests/test_celestial_intermediary.py
+++ b/punchbowl/level3/tests/test_celestial_intermediary.py
@@ -174,8 +174,6 @@ def test_shift_image_onto_fill_value(tmp_path):
         for hdu in hdul[1:]:
             hdu.header['CRVAL1A'] += 10
             hdu.header['CRVAL2A'] += 10
-            # Cut down to one Stokes component to speed up the test
-            hdu.data = hdul[1].data[0]
         hdul.writeto(file2)
 
     cube1 = io.load_ndcube_from_fits(file1, key='A')


### PR DESCRIPTION
## PR summary

Before I realized that most of the starfield read-in time was decompression, I tried this. This saves 1.3 seconds for loading the starfield map (from 2 s to .7 s) by avoid memory allocations, but maybe saving a smidge of time for every FITS read-in will add up over the whole pipeline.