### PR TITLE
Be a little more accurate/safe with bounding boxes

### DIFF
--- a/punchbowl/level2/resample.py
+++ b/punchbowl/level2/resample.py
@@ -53,8 +53,8 @@ def reproject_cube(input_cube: NDCube, output_wcs: WCS, output_shape: tuple[int,
     # reproject, we don't want it spending time looping over all those empty pixels, calculating coordinates,
     # etc. So here we find a bounding box around the input in the output frame and crop to that before reprojecting.
     # To start, here we make a grid of points along the edges of the input image.
-    xs = np.linspace(1, input_cube.data.shape[-1], 60)
-    ys = np.linspace(1, input_cube.data.shape[-2], 60)
+    xs = np.linspace(-1, input_cube.data.shape[-1], 60)
+    ys = np.linspace(-1, input_cube.data.shape[-2], 60)
     edgex = np.concatenate((xs, np.full(len(ys), xs[-1]), xs, np.zeros(len(ys))))
     edgey = np.concatenate((np.zeros(len(xs)), ys, np.full(len(xs), ys[-1]), ys))
 

--- a/punchbowl/level3/celestial_intermediary.py
+++ b/punchbowl/level3/celestial_intermediary.py
@@ -58,8 +58,8 @@ def to_celestial_frame_cutout(data_cube: NDCube, cdelt: float = 0.02) -> NDCube:
     wcs_out.wcs.crval = ((crval[0] // cdelt) * cdelt) % 360, 0
 
     # Now find the exact bounds of the input image in this output frame, so we can set the output array size
-    xs = np.linspace(1, data.shape[-1], 30)
-    ys = np.linspace(1, data.shape[-2], 30)
+    xs = np.linspace(-1, data.shape[-1], 30)
+    ys = np.linspace(-1, data.shape[-2], 30)
     edgex = np.concatenate((xs, np.full(len(ys), xs[-1]), xs, np.zeros(len(ys))))
     edgey = np.concatenate((np.zeros(len(xs)), ys, np.full(len(xs), ys[-1]), ys))
 


### PR DESCRIPTION
## PR summary

I remembered last night that Astropy has pixel centers at integer coordinates, so the image actually starts at -0.5, not 0, and so when we find a bounding box for mosaic reprojection (and also in the celestial intermediary code), the points we position along the edges of the input image should be along (x,y) = -0.5.

This PR puts them at -1, just for good measure. (The other side was already at `shape[0]` or `shape[1]`, so it was already just a smidge past the actual edge which is at `shape[0] - 0.5`.)

I don't know why I'd originally set the points at (x,y) = 1 instead of (x,y) = 0. I'd count that as a bug, though it apparently wasn't affecting the test case I did yesterday.

## Test plan

This just makes the bounding box bigger, so it shouldn't affect anything.