### PR TITLE
Better f corona

### DIFF
--- a/punchbowl/level1/stray_light.py
+++ b/punchbowl/level1/stray_light.py
@@ -15,70 +15,7 @@ from punchbowl.exceptions import (
     LargeTimeDeltaWarning,
 )
 from punchbowl.prefect import punch_task
-
-
-def _zvalue_from_index(arr, ind):  # noqa: ANN202, ANN001
-    """
-    Do math.
-
-    Private helper function to work around the limitation of np.choose() by employing np.take().
-    arr has to be a 3D array
-    ind has to be a 2D array containing values for z-indicies to take from arr
-    See: http://stackoverflow.com/a/32091712/4169585
-    This is faster and more memory efficient than using the ogrid based solution with fancy indexing.
-    """
-    # get number of columns and rows
-    _, n_cols, n_rows = arr.shape
-
-    # get linear indices and extract elements with np.take()
-    idx = n_cols*n_rows*ind + n_rows*np.arange(n_rows)[:,None] + np.arange(n_cols)
-    return np.take(arr, idx)
-
-
-def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
-    """Calculate the nan percentile faster of a 3D cube."""
-    # np.nanpercentile is slow so use this: https://krstn.eu/np.nanpercentile()-there-has-to-be-a-faster-way/
-
-    # valid (non NaN) observations along the first axis
-    valid_obs = np.sum(np.isfinite(arr), axis=0)
-    # replace NaN with maximum
-    max_val = np.nanmax(arr)
-    arr[np.isnan(arr)] = max_val
-    # sort - former NaNs will move to the end
-    arr = np.sort(arr, axis=0)
-
-    # loop over requested quantiles
-    if isinstance(q, list):
-        qs = []
-        qs.extend(q)
-    else:
-        qs = [q]
-
-    if len(qs) < 2:
-        quant_arr = np.zeros(shape=(arr.shape[1], arr.shape[2]))
-    else:
-        quant_arr = np.zeros(shape=(len(qs), arr.shape[1], arr.shape[2]))
-
-    result = []
-    for i in range(len(qs)):
-        quant = qs[i]
-        # desired position as well as floor and ceiling of it
-        k_arr = (valid_obs - 1) * (quant / 100.0)
-        f_arr = np.floor(k_arr).astype(np.int32)
-        c_arr = np.ceil(k_arr).astype(np.int32)
-        fc_equal_k_mask = f_arr == c_arr
-
-        # linear interpolation (like numpy percentile) takes the fractional part of desired position
-        floor_val = _zvalue_from_index(arr=arr, ind=f_arr) * (c_arr - k_arr)
-        ceil_val = _zvalue_from_index(arr=arr, ind=c_arr) * (k_arr - f_arr)
-
-        quant_arr = floor_val + ceil_val
-        # if floor == ceiling take floor value
-        quant_arr[fc_equal_k_mask] = _zvalue_from_index(arr=arr, ind=k_arr.astype(np.int32))[fc_equal_k_mask]
-
-        result.append(quant_arr)
-
-    return result
+from punchbowl.util import nan_percentile
 
 
 def estimate_stray_light(filepaths: [str], percentile: float = 3) -> np.ndarray:

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -103,10 +103,10 @@ def model_fcorona_for_cube(xt: np.ndarray,
         low, center, high = nan_percentile(cube, [25, 50, 75])
         width = high - low
         a, b, c = np.where(cube[:, ...] > (center + (smooth_level * width)))
-        cube[a, b, c] = center[b, c]
+        cube[a, b, c] = np.nan
 
         a, b, c = np.where(cube[:, ...] < (center - (smooth_level * width)))
-        cube[a, b, c] = center[b, c]
+        cube[a, b, c] = np.nan
 
     xt = np.array(xt)
     reference_xt -= xt[0]

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -12,6 +12,7 @@ from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.data.wcs import load_quickpunch_mosaic_wcs, load_trefoil_wcs
 from punchbowl.exceptions import InvalidDataError
 from punchbowl.prefect import punch_task
+from punchbowl.util import nan_percentile
 
 
 def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
@@ -60,13 +61,13 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
 
 def model_fcorona_for_cube(xt: np.ndarray,
                            reference_xt: float,
-                          cube: np.ndarray,
-                          min_brightness: float = 1E-18,
-                          smooth_level: float | None = 1,
-                          return_full_curves: bool=False,
+                           cube: np.ndarray,
+                           min_brightness: float = 1E-18,
+                           smooth_level: float | None = 1,
+                           return_full_curves: bool=False,
                           ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    Model the F corona given a list of times and a corresponding data cube, .
+    Model the F corona given a list of times and a corresponding data cube.
 
     Parameters
     ----------
@@ -99,8 +100,8 @@ def model_fcorona_for_cube(xt: np.ndarray,
     """
     cube[cube < min_brightness] = np.nan
     if smooth_level is not None:
-        center = np.nanmedian(cube, axis=0)
-        width = np.diff(np.nanpercentile(cube, [25, 75], axis=0), axis=0).squeeze()
+        low, center, high = nan_percentile(cube, [25, 50, 75])
+        width = high - low
         a, b, c = np.where(cube[:, ...] > (center + (smooth_level * width)))
         cube[a, b, c] = center[b, c]
 

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -126,4 +126,6 @@ def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
 
         result[i] = quant_arr
 
+    result[:, valid_obs == 0] = np.nan
+
     return result

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -107,11 +107,6 @@ def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
     else:
         qs = [q]
 
-    if len(qs) < 2:
-        quant_arr = np.zeros(shape=(arr.shape[1], arr.shape[2]))
-    else:
-        quant_arr = np.zeros(shape=(len(qs), arr.shape[1], arr.shape[2]))
-
     result = np.empty((len(qs), *arr.shape[1:]))
     for i in range(len(qs)):
         quant = qs[i]

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -112,7 +112,7 @@ def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
     else:
         quant_arr = np.zeros(shape=(len(qs), arr.shape[1], arr.shape[2]))
 
-    result = []
+    result = np.empty((len(qs), *arr.shape[1:]))
     for i in range(len(qs)):
         quant = qs[i]
         # desired position as well as floor and ceiling of it
@@ -129,6 +129,6 @@ def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
         # if floor == ceiling take floor value
         quant_arr[fc_equal_k_mask] = _zvalue_from_index(arr=arr, ind=k_arr.astype(np.int32))[fc_equal_k_mask]
 
-        result.append(quant_arr)
+        result[i] = quant_arr
 
     return result

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -68,3 +68,67 @@ def average_datetime(datetimes: list[datetime]) -> datetime:
     timestamps = [dt.timestamp() for dt in datetimes]
     average_timestamp = sum(timestamps) / len(timestamps)
     return datetime.fromtimestamp(average_timestamp)  # noqa: DTZ006
+
+
+def _zvalue_from_index(arr, ind):  # noqa: ANN202, ANN001
+    """
+    Do math.
+
+    Private helper function to work around the limitation of np.choose() by employing np.take().
+    arr has to be a 3D array
+    ind has to be a 2D array containing values for z-indicies to take from arr
+    See: http://stackoverflow.com/a/32091712/4169585
+    This is faster and more memory efficient than using the ogrid based solution with fancy indexing.
+    """
+    # get number of columns and rows
+    _, n_cols, n_rows = arr.shape
+
+    # get linear indices and extract elements with np.take()
+    idx = n_cols*n_rows*ind + n_rows*np.arange(n_rows)[:,None] + np.arange(n_cols)
+    return np.take(arr, idx)
+
+
+def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
+    """Calculate the nan percentile faster of a 3D cube."""
+    # np.nanpercentile is slow so use this: https://krstn.eu/np.nanpercentile()-there-has-to-be-a-faster-way/
+
+    # valid (non NaN) observations along the first axis
+    valid_obs = np.sum(np.isfinite(arr), axis=0)
+    # replace NaN with maximum
+    max_val = np.nanmax(arr)
+    arr[np.isnan(arr)] = max_val
+    # sort - former NaNs will move to the end
+    arr = np.sort(arr, axis=0)
+
+    # loop over requested quantiles
+    if isinstance(q, list):
+        qs = []
+        qs.extend(q)
+    else:
+        qs = [q]
+
+    if len(qs) < 2:
+        quant_arr = np.zeros(shape=(arr.shape[1], arr.shape[2]))
+    else:
+        quant_arr = np.zeros(shape=(len(qs), arr.shape[1], arr.shape[2]))
+
+    result = []
+    for i in range(len(qs)):
+        quant = qs[i]
+        # desired position as well as floor and ceiling of it
+        k_arr = (valid_obs - 1) * (quant / 100.0)
+        f_arr = np.floor(k_arr).astype(np.int32)
+        c_arr = np.ceil(k_arr).astype(np.int32)
+        fc_equal_k_mask = f_arr == c_arr
+
+        # linear interpolation (like numpy percentile) takes the fractional part of desired position
+        floor_val = _zvalue_from_index(arr=arr, ind=f_arr) * (c_arr - k_arr)
+        ceil_val = _zvalue_from_index(arr=arr, ind=c_arr) * (k_arr - f_arr)
+
+        quant_arr = floor_val + ceil_val
+        # if floor == ceiling take floor value
+        quant_arr[fc_equal_k_mask] = _zvalue_from_index(arr=arr, ind=k_arr.astype(np.int32))[fc_equal_k_mask]
+
+        result.append(quant_arr)
+
+    return result


### PR DESCRIPTION
## PR summary

- Improves the `nan_percentile` function a bit
- Uses it for F-corona estimation
- Rolls the median into that percentile call
- Stops imputing fill values for the points that get smoothed out, instead letting them be nans that get filtered out in the cubic fit

This does not:
- Do the detrending we were looking at today

This should be a good deal faster, and should produce fewer weird values in the F-corona model because we're not using insufficient fill values for the smoothing.
