### PR TITLE
Create starfield estimates that are less distorted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
         "pylibjpeg",
         "python-dateutil",
         "thuban",
-        "remove_starfield",
+        "remove_starfield>=0.0.4",
         "quadprog",
         "pylibjpeg[openjpeg]",
         "requests",


### PR DESCRIPTION
## PR summary

**This requires `remove_starfield` v0.0.4**

This makes a starfield map that doesn't curve up and down. This means less distortion (unsure if that affects the accuracy of the starfield subtraction) and should offer more speed for the map create (since not blowing things up at extreme declination ought to mean fewer output pixels to reprojection while still capturing everything). Likewise, since this should enable smaller maps, it ought to speed up the subtraction step where it's loading in the star map.

Before:
![image](https://github.com/user-attachments/assets/fa7ea29f-4ab6-44bf-86a4-eafa896ab782)

After:
![image](https://github.com/user-attachments/assets/e88ff498-ea61-4305-821b-9d29504ab9dd)


## Todos

None

## Test plan

Run it overnight
