### PR TITLE
return of vignetting

### DIFF
--- a/punchbowl/level1/tests/test_flow.py
+++ b/punchbowl/level1/tests/test_flow.py
@@ -15,9 +15,11 @@ def test_core_flow_runs_with_filenames(sample_ndcube, tmpdir):
         output_name = os.path.join(tmpdir, "test_output.fits")
         write_ndcube_to_fits(sample_ndcube(shape=(10, 10), code="CR1", level="0"), input_name)
         quartic_coefficient_path = THIS_DIRECTORY / "data" / "test_quartic_coeffs.fits"
+        vignetting_path = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
         with prefect_test_harness():
             output = level1_core_flow([input_name],
                                       quartic_coefficient_path=quartic_coefficient_path,
+                                      vignetting_function_path=vignetting_path,
                                       output_filename=[output_name])
         assert isinstance(output[0], NDCube)
         assert os.path.exists(output_name[0])
@@ -27,8 +29,10 @@ def test_core_flow_runs_with_filenames(sample_ndcube, tmpdir):
 def test_core_flow_runs_with_objects_and_calibration_files(sample_ndcube):
     cube = sample_ndcube(shape=(10, 10), code="CR1", level="0")
     quartic_coefficient_path = THIS_DIRECTORY / "data" / "test_quartic_coeffs.fits"
+    vignetting_path = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
 
     with prefect_test_harness():
         output = level1_core_flow([cube],
-                                  quartic_coefficient_path=quartic_coefficient_path)
+                                  quartic_coefficient_path=quartic_coefficient_path,
+                                  vignetting_function_path=vignetting_path,)
     assert isinstance(output[0], NDCube)

--- a/punchbowl/level1/tests/test_vignette.py
+++ b/punchbowl/level1/tests/test_vignette.py
@@ -1,0 +1,123 @@
+import pathlib
+from datetime import datetime
+
+import numpy as np
+import pytest
+from ndcube import NDCube
+from prefect.logging import disable_run_logger
+
+from punchbowl.data.tests.test_io import sample_ndcube
+from punchbowl.exceptions import (
+    IncorrectPolarizationStateWarning,
+    IncorrectTelescopeWarning,
+    InvalidDataError,
+    LargeTimeDeltaWarning,
+)
+from punchbowl.level1.vignette import correct_vignetting_task
+
+THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
+
+
+@pytest.mark.prefect_test()
+def test_check_calibration_time_delta_warning(sample_ndcube) -> None:
+    """
+    If the time between the data of interest and the calibration file is too great, then a warning is raised.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10))
+    sample_data.meta['DATE-OBS'].value = str(datetime(2022, 2, 22, 16, 0, 1))
+    vignetting_filename = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
+
+    with disable_run_logger():
+        with pytest.warns(LargeTimeDeltaWarning):
+            corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+            assert isinstance(corrected_punchdata, NDCube)
+
+
+@pytest.mark.prefect_test()
+def test_no_vignetting_file(sample_ndcube) -> None:
+    """
+    An invalid vignetting file should be provided. Check that an error is raised.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10), code="CR1", level="0")
+    vignetting_filename = None
+
+    with disable_run_logger():
+        corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+        assert isinstance(corrected_punchdata, NDCube)
+        assert corrected_punchdata.meta.history[0].comment == 'Vignetting skipped'
+
+
+@pytest.mark.prefect_test()
+def test_invalid_vignetting_file(sample_ndcube) -> None:
+    """
+    An invalid vignetting file should be provided. Check that an error is raised.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10), code="CR1", level="0")
+    vignetting_filename = THIS_DIRECTORY / "data" / "bogus_filename.fits"
+
+    with disable_run_logger():
+        with pytest.raises(InvalidDataError):
+            corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+
+
+@pytest.mark.prefect_test()
+def test_invalid_polarization_state(sample_ndcube) -> None:
+    """
+    Check that a mismatch between polarization states in the vignetting function and data raises an error.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10))
+    vignetting_filename = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
+
+    with disable_run_logger():
+        with pytest.warns(IncorrectPolarizationStateWarning):
+            corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+            assert isinstance(corrected_punchdata, NDCube)
+
+
+@pytest.mark.prefect_test()
+def test_invalid_telescope(sample_ndcube) -> None:
+    """
+    Check that a mismatch between telescopes in the vignetting function and data raises an error.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10))
+    sample_data.meta['TELESCOP'].value = 'PUNCH-2'
+    vignetting_filename = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
+
+    with disable_run_logger():
+        with pytest.warns(IncorrectTelescopeWarning):
+            corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+            assert isinstance(corrected_punchdata, NDCube)
+
+
+@pytest.mark.prefect_test()
+def test_invalid_data_file(sample_ndcube) -> None:
+    """
+    An invalid vignetting file should be provided. Check that an error is raised.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10), code="CR1", level="0")
+    vignetting_filename = THIS_DIRECTORY / "non_existent_file.fits"
+
+    with disable_run_logger():
+        with pytest.raises(InvalidDataError):
+            corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+
+
+@pytest.mark.prefect_test()
+def test_vignetting_correction(sample_ndcube) -> None:
+    """
+    A valid vignetting file should be provided. Check that a corrected PUNCHData object is generated.
+    """
+
+    sample_data = sample_ndcube(shape=(10, 10), code="CR1", level="0")
+    vignetting_filename = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
+
+    with disable_run_logger():
+        corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
+
+    assert isinstance(corrected_punchdata, NDCube)

--- a/punchbowl/level1/tests/test_vignette.py
+++ b/punchbowl/level1/tests/test_vignette.py
@@ -5,6 +5,7 @@ import pytest
 from ndcube import NDCube
 from prefect.logging import disable_run_logger
 
+from punchbowl.data.tests.test_punch_io import sample_ndcube
 from punchbowl.exceptions import (
     IncorrectPolarizationStateWarning,
     IncorrectTelescopeWarning,

--- a/punchbowl/level1/tests/test_vignette.py
+++ b/punchbowl/level1/tests/test_vignette.py
@@ -1,12 +1,10 @@
 import pathlib
 from datetime import datetime
 
-import numpy as np
 import pytest
 from ndcube import NDCube
 from prefect.logging import disable_run_logger
 
-from punchbowl.data.tests.test_io import sample_ndcube
 from punchbowl.exceptions import (
     IncorrectPolarizationStateWarning,
     IncorrectTelescopeWarning,

--- a/punchbowl/level1/vignette.py
+++ b/punchbowl/level1/vignette.py
@@ -1,0 +1,95 @@
+import os
+import pathlib
+import warnings
+
+from ndcube import NDCube
+from prefect import get_run_logger
+
+from punchbowl.data import load_ndcube_from_fits
+from punchbowl.exceptions import (
+    IncorrectPolarizationStateWarning,
+    IncorrectTelescopeWarning,
+    InvalidDataError,
+    LargeTimeDeltaWarning,
+    NoCalibrationDataWarning,
+)
+from punchbowl.prefect import punch_task
+
+
+@punch_task
+def correct_vignetting_task(data_object: NDCube, vignetting_path: pathlib) -> NDCube:
+    """
+    Prefect task to correct the vignetting of an image.
+
+    Vignetting is a reduction of an image's brightness or saturation toward the
+    periphery compared to the image center, created by the optical path. The
+    Vignetting Module will transform the data through a flat-field correction
+    map, to cancel out the effects of optical vignetting created by distortions
+    in the optical path. This module also corrects detector gain variation and
+    offset.
+
+    Correction maps will be 2048*2048 arrays, to match the input data, and
+    built using the starfield brightness pattern. Mathematical Operation:
+
+        I'_{i,j} = I_i,j * FF_{i,j}
+
+    Where I_{i,j} is the number of counts in pixel i, j. I'_{i,j} refers to the
+    modified value. FF_{i,j} is the small-scale flat field factor for pixel i,
+    j. The correction mapping will take into account the orientation of the
+    spacecraft and its position in the orbit.
+
+    Uncertainty across the image plane is calculated using the modelled
+    flat-field correction with stim lamp calibration data. Deviations from the
+    known flat-field are used to calculate the uncertainty in a given pixel.
+    The uncertainty is convolved with the input uncertainty layer to produce
+    the output uncertainty layer.
+
+
+    Parameters
+    ----------
+    data_object : PUNCHData
+        data on which to operate
+
+    vignetting_path : pathlib
+        path to vignetting function to apply to input data
+
+    Returns
+    -------
+    PUNCHData
+        modified version of the input with the vignetting corrected
+
+    """
+    logger = get_run_logger()
+    logger.info("correct_vignetting started")
+
+    if vignetting_path is None:
+        data_object.meta.history.add_now("LEVEL1-correct_vignetting", "Vignetting skipped")
+        msg=f"Calibration file {vignetting_path} is unavailable, vignetting correction not applied"
+        warnings.warn(msg, NoCalibrationDataWarning)
+    elif not vignetting_path.exists():
+        msg = f"File {vignetting_path} does not exist."
+        raise InvalidDataError(msg)
+    else:
+        vignetting_function = load_ndcube_from_fits(vignetting_path)
+        vignetting_function_date = vignetting_function.meta.astropy_time
+        observation_date = data_object.meta.astropy_time
+        if abs((vignetting_function_date - observation_date).to("day").value) > 14:
+            msg = f"Calibration file {vignetting_path} contains data created greater than 2 weeks from the obsveration"
+            warnings.warn(msg, LargeTimeDeltaWarning)
+        if vignetting_function.meta["TELESCOP"].value != data_object.meta["TELESCOP"].value:
+            msg = f"Incorrect TELESCOP value within {vignetting_path}"
+            warnings.warn(msg, IncorrectTelescopeWarning)
+        if vignetting_function.meta["OBSLAYR1"].value != data_object.meta["OBSLAYR1"].value:
+            msg = f"Incorrect polarization state within {vignetting_path}"
+            warnings.warn(msg, IncorrectPolarizationStateWarning)
+        if vignetting_function.data.shape != data_object.data.shape:
+            msg = f"Incorrect vignetting function shape within {vignetting_path}"
+            raise InvalidDataError(msg)
+
+        data_object.data[:, :] = data_object.data[:, :] / vignetting_function.data[:, :]
+        data_object.uncertainty.array[:, :] /= vignetting_function.data[:, :]
+        data_object.meta.history.add_now("LEVEL1-correct_vignetting",
+                                         f"Vignetting corrected using {os.path.basename(str(vignetting_path))}")
+        data_object.meta["CALVI"] = os.path.basename(str(vignetting_path))
+    logger.info("correct_vignetting finished")
+    return data_object


### PR DESCRIPTION
## PR summary

Disentangles vignetting from the quartic fit module, re-establishing it as a separate module and calibration input.

## Todos

- [x] Check restored module functionality
- [ ] Re-create initial decoupled calibration files
- [x] Update any scripts for generating calibration data
- [ ] Reinitialize vignetting in punchpipe

## Related Issues

Closes #351 
