### PR TITLE
Update GALLERY_HEADER.rst

### DIFF
--- a/examples/GALLERY_HEADER.rst
+++ b/examples/GALLERY_HEADER.rst
@@ -1,4 +1,4 @@
-PUNCH Example Gallery
-=====================
+Examples
+========
 
 Below is a gallery of examples working with PUNCH data.


### PR DESCRIPTION
Right now the example gallery has a long name.

<img width="1198" alt="Screenshot 2025-02-08 at 19 19 59" src="https://github.com/user-attachments/assets/818ee465-abe8-4214-95c5-9e5171e21746" />

It's obvious it's PUNCH so let's shorten it for readability. 