### PR TITLE
Update binder.yaml

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -11,7 +11,7 @@ jobs:
   deploy-binder:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   
+      contents: write
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -32,6 +32,7 @@ jobs:
         cd ./docs; make html; cd ..
         mkdir notebooks
         mkdir notebooks/auto_examples/
+        cp -r punchbowl/ notebooks/auto_examples/
         cp docs/binder/requirements.txt notebooks/auto_examples/
         cp docs/binder/requirements.txt .
         cp docs/auto_examples/*.ipynb notebooks/auto_examples/


### PR DESCRIPTION
This makes binder work maybe... just copies punchbowl into the source directory so it's available. That *might* work. 