### PR TITLE
Fix radec wcs

### DIFF
--- a/punchbowl/data/tests/test_wcs.py
+++ b/punchbowl/data/tests/test_wcs.py
@@ -138,60 +138,68 @@ def test_wcs_many_point_2d_check():
 
 
 def test_wcs_many_point_3d_check():
-    m = NormalizedMetadata.load_template("PSM", "3")
-    date_obs = Time("2024-01-01T00:00:00", format='isot', scale='utc')
-    m['DATE-OBS'] = str(date_obs)
-    sun_radec = get_sun(date_obs)
-
-    wcs_celestial = WCS({"CRVAL1": sun_radec.ra.to(u.deg).value,
-                         "CRVAL2": sun_radec.dec.to(u.deg).value,
+    for date_obs, crval1, crval2, crot in product(
+            ["2021-03-20T00:00:00", "2021-01-20T00:00:00"],
+            [-20, 10, 30],
+            [-10, 0, 10],
+            [-30, 0, 30] * u.deg):
+        earth = get_earth(date_obs)
+        wcs_helio = WCS({"CRVAL1": crval1,
+                         "CRVAL2": crval2,
+                         "CRVAL3": 0,
                          "CRPIX1": 2047.5,
                          "CRPIX2": 2047.5,
                          "CRPIX3": 0,
-                         "CDELT1": -0.0225,
+                         "NAXIS1": 4096,
+                         "NAXIS2": 4096,
+                         "NAXIS3": 3,
+                         "CDELT1": 0.0225,
                          "CDELT2": 0.0225,
                          "CDELT3": 1.0,
                          "CUNIT1": "deg",
                          "CUNIT2": "deg",
                          "CUNIT3": "",
-                         "CTYPE1": "RA---ARC",
-                         "CTYPE2": "DEC--ARC",
-                         "CTYPE3": "STOKES"})
+                         "CTYPE1": "HPLN-AZP",
+                         "CTYPE2": "HPLT-AZP",
+                         "CTYPE3": "STOKES",
+                         "PC1_1": np.cos(crot).value,
+                         "PC1_2": -np.sin(crot).value,
+                         "PC2_1": np.sin(crot).value,
+                         "PC2_2": np.cos(crot).value,
+                         "DATE-OBS": date_obs,
+                         "MJD-OBS": Time(date_obs).mjd,
+                         "DSUN_OBS": earth.radius.to_value(u.m),
+                         "HGLN_OBS": earth.lon.to_value(u.deg),
+                         "HGLT_OBS": earth.lat.to_value(u.deg),
+                         "PV2_1": 0,
+                         })
 
-    # we're at the center of the Earth so let's try that
-    test_loc = EarthLocation.from_geocentric(0, 0, 0, unit=u.m)
-    test_gcrs = SkyCoord(test_loc.get_gcrs(date_obs))
+        wcs_celestial = calculate_celestial_wcs_from_helio(wcs_helio)
 
+        npoints = 20
+        xs, ys = np.meshgrid(
+            np.linspace(0, wcs_helio.pixel_shape[0], npoints),
+            np.linspace(0, wcs_helio.pixel_shape[1], npoints))
+        zs = np.ones_like(xs)
 
-    wcs_helio, _ = calculate_helio_wcs_from_celestial(wcs_celestial, date_obs,(2, 4096, 4096))
+        hp_coords = wcs_helio.pixel_to_world(xs, ys, zs)
+        # These come out claiming to be ICRS, but they're really GCRS (since it doesn't seem possible to tell a WCS
+        # that it's GCRS)
+        eq_coords = wcs_celestial.pixel_to_world(xs, ys, zs)
+        hp_to_eq_coords = hp_coords[0].transform_to('gcrs')
 
-    npoints = 20
-    input_coords = np.stack([
-                             np.linspace(0, 4096, npoints).astype(int),
-                             np.linspace(0, 4096, npoints).astype(int),
-                             np.ones(npoints, dtype=int),], axis=1)
+        eq_ra = eq_coords[0].ra.to_value(u.deg)
+        hp_to_eq_ra = hp_to_eq_coords.ra.to_value(u.deg)
+        straddles_wrap = np.nonzero(np.abs(eq_ra - hp_to_eq_ra) > 350)
+        for r, c in zip(*straddles_wrap):
+            if eq_ra[r, c] > 350:
+                eq_ra[r, c] -= 360
+            else:
+                hp_to_eq_ra[r, c] -= 360
 
-    points_celestial = wcs_celestial.all_pix2world(input_coords, 0)
-    points_helio = wcs_helio.all_pix2world(input_coords, 0)
-
-    output_coords = []
-    for c_pix, c_celestial, c_helio in zip(input_coords, points_celestial, points_helio):
-        skycoord_celestial = SkyCoord(c_celestial[0] * u.deg, c_celestial[1] * u.deg,
-                                      frame=GCRS,
-                                      obstime=date_obs,
-                                      observer=test_gcrs,
-                                      obsgeoloc=test_gcrs.cartesian,
-                                      obsgeovel=test_gcrs.velocity.to_cartesian(),
-                                      distance=test_gcrs.hcrs.distance
-                                      )
-
-        intermediate = skycoord_celestial.transform_to(frames.Helioprojective)
-        output_coords.append(wcs_helio.all_world2pix(intermediate.data.lon.to(u.deg).value,
-                                                     intermediate.data.lat.to(u.deg).value, 2, 0))
-
-    output_coords = np.array(output_coords)
-    distances = np.linalg.norm(input_coords - output_coords, axis=1)
-    assert np.nanmean(distances) < 0.1
+        np.testing.assert_allclose(eq_ra, hp_to_eq_ra, atol=1e-12)
+        np.testing.assert_allclose(eq_coords[0].dec.to_value(u.deg), hp_to_eq_coords.dec.to_value(u.deg), atol=1e-12)
+        np.testing.assert_array_equal(hp_coords[1], eq_coords[1])
 
 
 def test_load_trefoil_wcs():

--- a/punchbowl/data/wcs.py
+++ b/punchbowl/data/wcs.py
@@ -72,7 +72,7 @@ def calculate_helio_wcs_from_celestial(wcs_celestial: WCS,
 
     rotation_angle = -compute_hp_to_eq_rotation_angle(wcs_helio, date_obs)
     rotation_angle -= extract_crota_from_wcs(wcs_celestial)
-    new_pc_matrix = calculate_pc_matrix(rotation_angle, wcs_celestial.wcs.cdelt)
+    new_pc_matrix = calculate_pc_matrix(rotation_angle, wcs_helio.wcs.cdelt)
     wcs_helio.wcs.pc = new_pc_matrix
 
     if is_3d:

--- a/punchbowl/data/wcs.py
+++ b/punchbowl/data/wcs.py
@@ -275,8 +275,14 @@ def gcrs_to_hpc(GCRScoord, Helioprojective): # noqa: ANN201, N803, ANN001
     return Helioprojective.realize_frame(rep)
 
 
-def calculate_celestial_wcs_from_helio(wcs_helio: WCS, date_obs: astropy.time.Time, data_shape: tuple[int, int]) -> WCS:
+def calculate_celestial_wcs_from_helio(wcs_helio: WCS,
+                                       date_obs: astropy.time.Time | None=None,
+                                       data_shape: tuple[int, int] | None=None) -> WCS:
     """Calculate the celestial WCS from a helio WCS."""
+    if date_obs is None:
+        date_obs = wcs_helio.wcs.dateobs
+    if data_shape is None:
+        data_shape = wcs_helio.array_shape
     is_3d = len(data_shape) == 3
 
     old_crval = SkyCoord(wcs_helio.wcs.crval[0] * u.deg, wcs_helio.wcs.crval[1] * u.deg,

--- a/punchbowl/data/wcs.py
+++ b/punchbowl/data/wcs.py
@@ -355,7 +355,7 @@ def compute_hp_to_eq_rotation_angle(wcs_helio: WCS) -> u.Quantity:
 
     """
     # Get our CRVAL vector
-    axis_sc = wcs_helio.pixel_to_world(wcs_helio.wcs.crpix[0] - 1, wcs_helio.wcs.crpix[1] - 1)
+    axis_sc = wcs_helio.celestial.pixel_to_world(wcs_helio.wcs.crpix[0] - 1, wcs_helio.wcs.crpix[1] - 1)
     axis = axis_sc.cartesian.xyz
     axis /= np.linalg.norm(axis)
 

--- a/punchbowl/level2/resample.py
+++ b/punchbowl/level2/resample.py
@@ -82,6 +82,7 @@ def reproject_cube(input_cube: NDCube, output_wcs: WCS, output_shape: tuple[int,
     reproject.reproject_adaptive(
         (input_data, celestial_source),
         celestial_target[ymin:ymax, xmin:xmax],
+        shape_out=(2, np.max((ymax-ymin, 0)), np.max((xmax-xmin, 0))),
         roundtrip_coords=False, return_footprint=False,
         output_array=output_array[..., ymin:ymax, xmin:xmax],
     )

--- a/punchbowl/level2/tests/test_flow.py
+++ b/punchbowl/level2/tests/test_flow.py
@@ -8,6 +8,7 @@ from prefect.testing.utilities import prefect_test_harness
 
 from punchbowl.data.punch_io import write_ndcube_to_fits
 from punchbowl.data.tests.test_punch_io import sample_ndcube
+from punchbowl.data.wcs import load_trefoil_wcs
 from punchbowl.level2.flow import ORDER, level2_core_flow
 
 THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -21,8 +22,9 @@ def test_core_flow_runs_with_filenames(sample_ndcube, tmpdir):
         paths.append(path)
     voters = [[] for _ in data_list]
 
+    trefoil_wcs, _ = load_trefoil_wcs()
     with prefect_test_harness():
-        output = level2_core_flow(paths, voters, trefoil_wcs=WCS(naxis=2), trefoil_shape=(20, 20))
+        output = level2_core_flow(paths, voters, trefoil_wcs=trefoil_wcs, trefoil_shape=(4096, 4096))
     assert isinstance(output[0], NDCube)
 
 @pytest.mark.parametrize("drop_indices", [[], [1], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
@@ -30,7 +32,8 @@ def test_core_flow_runs_with_objects_and_calibration_files(sample_ndcube, drop_i
     data_list = [sample_ndcube(shape=(10, 10), code=code, level="1")
                  for i, code in enumerate(ORDER) if i not in drop_indices]
 
+    trefoil_wcs, _ = load_trefoil_wcs()
     voters = [[] for _ in data_list]
     with prefect_test_harness():
-        output = level2_core_flow(data_list, voters, trefoil_wcs=WCS(naxis=2), trefoil_shape=(20, 20))
+        output = level2_core_flow(data_list, voters, trefoil_wcs=trefoil_wcs, trefoil_shape=(4096, 4096))
     assert isinstance(output[0], NDCube)


### PR DESCRIPTION
## PR summary

Here we go!

## Todos

Two quirks to think about at some point

- [ ] The celestial WCS says it's ICRS, even though it's really GCRS
- [ ] The celestial WCS can have the observation date set, but it doesn't pass through to SkyCoords from `pixel_to_world` since ICRS doesn't care about your observation date

## Test plan

Run the tests!

## Breaking changes

None, but I think we should stop returning the P angle from `calculate_helio_wcs_from_celestial`