### PR TITLE
Parallelize f corona

### DIFF
--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -46,7 +46,6 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
     num_inputs = np.sum(cube_is_good, axis=0)
 
     solution = np.zeros((input_vals.shape[1], cube.shape[1], cube.shape[2]))
-    this_solution = np.zeros(input_vals.shape[1])
     for i in range(cube.shape[1]):
         start = time.time()
         for j in range(cube.shape[2]):

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 import multiprocessing as mp
 
@@ -39,6 +40,7 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
         Array of coefficients for solving polynomial
 
     """
+    logger = get_run_logger()
     c = np.transpose(input_vals)
     cube_is_good = np.isfinite(cube)
     num_inputs = np.sum(cube_is_good, axis=0)
@@ -46,6 +48,7 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
     solution = np.zeros((input_vals.shape[1], cube.shape[1], cube.shape[2]))
     this_solution = np.zeros(input_vals.shape[1])
     for i in range(cube.shape[1]):
+        start = time.time()
         for j in range(cube.shape[2]):
             is_good = cube_is_good[:, i, j]
             time_series = cube[:, i, j][is_good]
@@ -60,7 +63,8 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
                 except ValueError:
                     this_solution[:] = 0
             solution[:, i, j] = this_solution
-
+        end = time.time()
+        logger.info(f"{i} took {end - start} seconds")
     return np.asarray(solution), num_inputs
 
 

--- a/punchbowl/levelq/f_corona_model.py
+++ b/punchbowl/levelq/f_corona_model.py
@@ -50,7 +50,7 @@ def construct_qp_f_corona_model(filenames: list[str], smooth_level: float = 3.0,
     logger.info("ending data loading")
 
     reference_xt = reference_time.timestamp()
-    model_fcorona, _ = model_fcorona_for_cube(obs_times, reference_xt, data_cube, smooth_level=smooth_level)
+    model_fcorona, _ = model_fcorona_for_cube(obs_times, reference_xt, data_cube, clip_factor=smooth_level)
     model_fcorona[model_fcorona<=0] = np.nan
     model_fcorona = fill_nans_with_interpolation(model_fcorona)
 

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -96,6 +96,7 @@ def nan_percentile(arr: np.ndarray, q: list[float] | float) -> np.ndarray:
     is_good = np.isfinite(arr)
     n_valid_obs = np.sum(is_good, axis=0)
     # replace NaN with maximum
+    arr = arr.copy()
     arr[~is_good] = np.nanmax(arr)
     # sort - former NaNs will move to the end
     arr = np.sort(arr, axis=0)

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -81,10 +81,10 @@ def _zvalue_from_index(arr, ind):  # noqa: ANN202, ANN001
     This is faster and more memory efficient than using the ogrid based solution with fancy indexing.
     """
     # get number of columns and rows
-    _, n_cols, n_rows = arr.shape
+    _, n_rows, n_cols = arr.shape
 
     # get linear indices and extract elements with np.take()
-    idx = n_cols*n_rows*ind + n_rows*np.arange(n_rows)[:,None] + np.arange(n_cols)
+    idx = n_cols*n_rows*ind + n_cols*np.arange(n_rows)[:,None] + np.arange(n_cols)
     return np.take(arr, idx)
 
 


### PR DESCRIPTION
## PR summary

I'll wait to parallelize the nan-filling part of the F-corona generation until after we re-run things and see what the nan value distribution looks like. (A lot of nans were showing up because of the mis-assembled mosaics.) In the meantime, might as well get these other parts in.

This parallelizes the reading of input files and the building of the F-corona model.

I see now in your earlier commits in this branch `solve_qp_cube` was parallelized and then (mistakenly?) that was reverted. My version does it at a higher level in the call stack, so that the outlier rejection part is also in parallel.

## Todos

This can wait for a future PR:

- [ ] Parallelize the nan-filling part

## Test plan

While we were in SLO I ran the code before and after this parallelization and got identical results.

## Breaking changes

None

## Related Issues

This addresses part of #381