### PR TITLE
Create a punch_flow decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixes starfield polarization; checks times are in UTC in https://github.com/punch-mission/punchbowl/pull/328#pullrequestreview-2726230483
 - Fixes issues with calibration metadata in https://github.com/punch-mission/punchbowl/pull/404
 - Fixes a keyword typo in omniheader in https://github.com/punch-mission/punchbowl/pull/407
+- Creates a uses a custom PUNCH flow in prefect in https://github.com/punch-mission/punchbowl/pull/409
 
 ## Version 0.0.9: Feb 28, 2025
 

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -3,7 +3,7 @@ import pathlib
 import astropy.units as u
 import numpy as np
 from ndcube import NDCube
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 from regularizepsf import ArrayPSFBuilder, ArrayPSFTransform, simple_functional_psf
 from regularizepsf.util import calculate_covering
 
@@ -19,10 +19,11 @@ from punchbowl.level1.quartic_fit import perform_quartic_fit_task
 from punchbowl.level1.sqrt import decode_sqrt_data
 from punchbowl.level1.stray_light import remove_stray_light_task
 from punchbowl.level1.vignette import correct_vignetting_task
+from punchbowl.prefect import punch_flow
 from punchbowl.util import load_image_task, output_image_task
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def generate_psf_model_core_flow(input_filepaths: [str],
                                  alpha: float = 2.0,
                                  epsilon: float = 0.3,
@@ -42,7 +43,7 @@ def generate_psf_model_core_flow(input_filepaths: [str],
     return ArrayPSFTransform.construct(image_psf, target.as_array_psf(coords, psf_size), alpha, epsilon)
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def level1_core_flow(
     input_data: list[str] | list[NDCube],
     gain: float = 4.9,
@@ -144,7 +145,7 @@ def level1_core_flow(
     return output_data
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def levelh_core_flow(
     input_data: list[str] | list[NDCube],
     gain: float = 4.9,

--- a/punchbowl/level2/flow.py
+++ b/punchbowl/level2/flow.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs import WCS
 from ndcube import NDCube
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 from prefect_dask.task_runners import DaskTaskRunner
 
 from punchbowl.data import get_base_file_name, load_trefoil_wcs
@@ -13,6 +13,7 @@ from punchbowl.level2.bright_structure import identify_bright_structures_task
 from punchbowl.level2.merge import merge_many_clear_task, merge_many_polarized_task
 from punchbowl.level2.polarization import resolve_polarization_task
 from punchbowl.level2.resample import reproject_many_flow
+from punchbowl.prefect import punch_flow
 from punchbowl.util import average_datetime, load_image_task, output_image_task
 
 ORDER = ["PM1", "PZ1", "PP1",
@@ -21,7 +22,7 @@ ORDER = ["PM1", "PZ1", "PP1",
          "PM4", "PZ4", "PP4"]
 
 
-@flow(validate_parameters=False, task_runner=DaskTaskRunner(
+@punch_flow(task_runner=DaskTaskRunner(
     cluster_kwargs={"n_workers": 4, "threads_per_worker": 2},
 ))
 def level2_core_flow(data_list: list[str] | list[NDCube],
@@ -88,7 +89,7 @@ def level2_core_flow(data_list: list[str] | list[NDCube],
     return [output_data]
 
 
-@flow(validate_parameters=False, task_runner=DaskTaskRunner(
+@punch_flow(task_runner=DaskTaskRunner(
     cluster_kwargs={"n_workers": 4, "threads_per_worker": 2},
 ))
 def level2_ctm_flow(data_list: list[str] | list[NDCube],

--- a/punchbowl/level2/resample.py
+++ b/punchbowl/level2/resample.py
@@ -3,11 +3,10 @@ import numpy as np
 import reproject
 from astropy.wcs import WCS
 from ndcube import NDCube
-from prefect import flow
 from sunpy.coordinates import sun
 
 from punchbowl.data.wcs import calculate_celestial_wcs_from_helio
-from punchbowl.prefect import punch_task
+from punchbowl.prefect import punch_flow, punch_task
 
 
 @punch_task
@@ -90,7 +89,7 @@ def reproject_cube(input_cube: NDCube, output_wcs: WCS, output_shape: tuple[int,
     return output_array
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def reproject_many_flow(data: list[NDCube | None], trefoil_wcs: WCS, trefoil_shape: np.ndarray) -> list[NDCube | None]:
     """Reproject many flow."""
     out_layers = [reproject_cube.submit(d, trefoil_wcs, trefoil_shape) if d is not None else None for d in data]

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -7,7 +7,7 @@ import numpy as np
 from dateutil.parser import parse as parse_datetime_str
 from ndcube import NDCube
 from numpy.polynomial import polynomial
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 from quadprog import solve_qp
 from scipy.interpolate import griddata
 
@@ -15,7 +15,7 @@ from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.data.meta import set_spacecraft_location_to_earth
 from punchbowl.data.wcs import load_trefoil_wcs
 from punchbowl.exceptions import InvalidDataError
-from punchbowl.prefect import punch_task
+from punchbowl.prefect import punch_flow, punch_task
 from punchbowl.util import nan_percentile
 
 
@@ -197,7 +197,7 @@ def _load_one_file(filename: str) -> NDCube:
     return load_ndcube_from_fits(filename)
 
 
-@flow(log_prints=True)
+@punch_flow(log_prints=True)
 def construct_polarized_f_corona_model(filenames: list[str],
                                        clip_factor: float = 3.0,
                                        reference_time: str | None = None,

--- a/punchbowl/level3/flow.py
+++ b/punchbowl/level3/flow.py
@@ -2,7 +2,7 @@ import os
 from datetime import UTC, datetime
 
 from ndcube import NDCube
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 
 from punchbowl.data.meta import NormalizedMetadata, set_spacecraft_location_to_earth
 from punchbowl.level3.f_corona_model import subtract_f_corona_background_task
@@ -10,10 +10,11 @@ from punchbowl.level3.low_noise import create_low_noise_task
 from punchbowl.level3.polarization import convert_polarization
 from punchbowl.level3.stellar import subtract_starfield_background_task
 from punchbowl.level3.velocity import plot_flow_map, track_velocity
+from punchbowl.prefect import punch_flow
 from punchbowl.util import load_image_task, output_image_task
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def level3_PIM_flow(data_list: list[str] | list[NDCube],  # noqa: N802
                      before_f_corona_model_path: str,
                      after_f_corona_model_path: str,
@@ -48,7 +49,7 @@ def level3_PIM_flow(data_list: list[str] | list[NDCube],  # noqa: N802
     return out_list
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def level3_core_flow(data_list: list[str] | list[NDCube],
                      before_f_corona_model_path: str,
                      after_f_corona_model_path: str,
@@ -74,7 +75,7 @@ def level3_core_flow(data_list: list[str] | list[NDCube],
     return data_list
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def generate_level3_low_noise_flow(data_list: list[str] | list[NDCube],
                                    output_filename: str | None = None) -> list[NDCube]:
     """Generate low noise products."""
@@ -90,7 +91,7 @@ def generate_level3_low_noise_flow(data_list: list[str] | list[NDCube],
     return [low_noise_image]
 
 
-@flow(validate_parameters=False)
+@punch_flow
 def generate_level3_velocity_flow(data_list: list[str],
                                   output_filename: str | None = None) -> list[NDCube]:
     """Generate Level 3 velocity data product."""

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -7,14 +7,14 @@ import remove_starfield
 from astropy.wcs import WCS
 from dateutil.parser import parse as parse_datetime_str
 from ndcube import NDCollection, NDCube
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 from remove_starfield import ImageHolder, ImageProcessor, Starfield
 from remove_starfield.reducers import PercentileReducer
 from solpolpy import resolve
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.data.wcs import calculate_helio_wcs_from_celestial, get_p_angle
-from punchbowl.prefect import punch_task
+from punchbowl.prefect import punch_flow, punch_task
 
 
 def to_celestial(input_data: NDCube) -> NDCube:
@@ -112,7 +112,7 @@ class PUNCHImageProcessor(ImageProcessor):
         return ImageHolder(data, cube.wcs.celestial, cube.meta)
 
 
-@flow(log_prints=True, timeout_seconds=21_600)
+@punch_flow(log_prints=True, timeout_seconds=21_600)
 def generate_starfield_background(
         filenames: list[str],
         map_scale: float = 0.01,

--- a/punchbowl/levelq/f_corona_model.py
+++ b/punchbowl/levelq/f_corona_model.py
@@ -3,14 +3,15 @@ from datetime import UTC, datetime
 import numpy as np
 from dateutil.parser import parse as parse_datetime_str
 from ndcube import NDCube
-from prefect import flow, get_run_logger
+from prefect import get_run_logger
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.data.wcs import load_quickpunch_mosaic_wcs
 from punchbowl.level3.f_corona_model import fill_nans_with_interpolation, model_fcorona_for_cube
+from punchbowl.prefect import punch_flow
 
 
-@flow(log_prints=True)
+@punch_flow(log_prints=True)
 def construct_qp_f_corona_model(filenames: list[str], smooth_level: float = 3.0,
                                        reference_time: str | None = None) -> list[NDCube]:
     """Construct QuickPUNCH F corona model."""

--- a/punchbowl/prefect.py
+++ b/punchbowl/prefect.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from ndcube import NDCube
-from prefect import Task, get_run_logger, task
+from prefect import Flow, Task, flow, get_run_logger, task
 from prefect.client.schemas.objects import TaskRun
 from prefect.states import State
 from prefect.variables import Variable
@@ -30,3 +30,7 @@ def failure_hook(task: Task, task_run: TaskRun, state: State) -> None:
 def punch_task(*args: Any, **kwargs: Any) -> Task:
     """Prefect task that does PUNCH special things."""
     return task(*args, **kwargs, on_completion=[completion_debugger], on_failure=[failure_hook])
+
+def punch_flow(*args: Any, **kwargs: Any) -> Flow:
+    """Prefect flow that does PUNCH special things."""
+    return flow(*args, **kwargs, validate_parameters=False)


### PR DESCRIPTION
## PR summary

All flows in punchbowl are now `punch_flow`s!

In the future, this will let us easily point them all at a central Dask task executor. (Taking advantage of that will probably require making sure all parallelizable tasks are `.submit()`ed.

## Test plan

Tests pass
