### PR TITLE
Two small fixes

### DIFF
--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -25,11 +25,11 @@ from punchbowl.util import load_image_task, output_image_task
 
 
 @punch_flow
-def generate_psf_model_core_flow(input_filepaths: [str],
+def generate_psf_model_core_flow(input_filepaths: list[str],
                                  masks: list[pathlib.Path | str] | np.ndarray | Generator = None,
                                  alpha: float = 2.0,
                                  epsilon: float = 0.3,
-                                 image_shape: (int, int) = (2048, 2048),
+                                 image_shape: tuple[int, int] = (2048, 2048),
                                  psf_size: int = 32,
                                  target_fwhm: float = 3.25) -> ArrayPSFTransform:
     """Generate PSF model."""

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -12,7 +12,6 @@ from quadprog import solve_qp
 from scipy.interpolate import griddata
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
-from punchbowl.data.meta import set_spacecraft_location_to_earth
 from punchbowl.data.wcs import load_trefoil_wcs
 from punchbowl.exceptions import InvalidDataError
 from punchbowl.prefect import punch_flow, punch_task
@@ -284,7 +283,6 @@ def construct_polarized_f_corona_model(filenames: list[str],
                                                p_model_fcorona], axis=0),
                                 meta=meta,
                                 wcs=trefoil_3d_wcs)
-    output_cube = set_spacecraft_location_to_earth(output_cube)
 
     return [output_cube]
 


### PR DESCRIPTION
## PR summary

Fixes a pydantic warning

Doesn't try to set a spacecraft location for F corona models. It doesn't make sense, and for the clears, CFMs are [marked as calibration files](https://github.com/punch-mission/punchbowl/blob/1283c68fdf788e28496b826c2e6a926f27c67d99/punchbowl/data/data/Level3.yaml#L88) which don't include the right header keys to store this data. Does this need a changelog?