### PR TITLE
F-corona detrending, fixes for L2 metadata, and use header's gain and exposure time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Also available in GitHub](https://github.com/punch-mission/punchbowl/releases)
 
+## Unreleased
+
+- F-corona detrending, fixes for L2 FILEVRSN and DATE-OBS, and use header's gain and exposure time in https://github.com/punch-mission/punchbowl/pull/455
+
 ## Version 0.0.12: May 12, 2025
 
 - L1 speedups, L2 reprojection fix, and accepting ints for `float` fields in `NormalizedMetadata` in https://github.com/punch-mission/punchbowl/pull/435

--- a/punchbowl/data/meta.py
+++ b/punchbowl/data/meta.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import typing as t
-from datetime import datetime
+from datetime import UTC, datetime
 from collections import OrderedDict
 from collections.abc import Mapping
 
@@ -803,7 +803,7 @@ class NormalizedMetadata(Mapping):
         if "DATE-OBS" not in self:
             msg = "DATE-OBS is missing from the metadata."
             raise MissingMetadataError(msg)
-        return parse_datetime(self["DATE-OBS"].value)
+        return parse_datetime(self["DATE-OBS"].value).replace(tzinfo=UTC)
 
     @property
     def shape(self) -> tuple:

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -95,16 +95,16 @@ def level1_core_flow(
         data = perform_quartic_fit_task(data, quartic_coefficient_path)
 
         if data.meta["OBSCODE"].value == "4":
-            scaling = {"gain_left": 4.9 * u.photon / u.DN,
-                       "gain_right": 4.9 * u.photon / u.DN,
+            scaling = {"gain_left": data.meta["GAINLEFT"].value * u.photon / u.DN,
+                       "gain_right": data.meta["GAINRGHT"].value * u.photon / u.DN,
                        "wavelength": 530. * u.nm,
-                       "exposure": 49 * u.s,
+                       "exposure": data.meta["EXPTIME"].value * u.s,
                        "aperture": 49.57 * u.mm ** 2}
         else:
-            scaling = {"gain_left": 4.9 * u.photon / u.DN,
-                       "gain_right": 4.9 * u.photon / u.DN,
+            scaling = {"gain_left": data.meta["GAINLEFT"].value * u.photon / u.DN,
+                       "gain_right": data.meta["GAINRGHT"].value * u.photon / u.DN,
                        "wavelength": 530. * u.nm,
-                       "exposure": 49 * u.s,
+                       "exposure": data.meta["EXPTIME"].value * u.s,
                        "aperture": 34 * u.mm ** 2}
         pixel_scale = calculate_image_pixel_area(data.wcs, data.data.shape).to(u.sr) / u.pixel
         scaling["pixel_scale"] = pixel_scale

--- a/punchbowl/level1/tests/test_flow.py
+++ b/punchbowl/level1/tests/test_flow.py
@@ -18,6 +18,7 @@ def test_core_flow_runs_with_filenames(sample_ndcube, tmpdir):
         sample_data.meta["GAINLEFT"] = 4.9
         sample_data.meta["GAINRGHT"] = 4.9
         sample_data.meta["OFFSET"] = 100
+        sample_data.meta["EXPTIME"] = 49
         write_ndcube_to_fits(sample_data, input_name)
 
         quartic_coefficient_path = THIS_DIRECTORY / "data" / "test_quartic_coeffs.fits"
@@ -38,6 +39,7 @@ def test_core_flow_runs_with_objects_and_calibration_files(sample_ndcube):
     cube.meta["GAINLEFT"] = 4.9
     cube.meta["GAINRGHT"] = 4.9
     cube.meta["OFFSET"] = 100
+    cube.meta["EXPTIME"] = 49
     quartic_coefficient_path = THIS_DIRECTORY / "data" / "test_quartic_coeffs.fits"
     vignetting_path = THIS_DIRECTORY / "data" / "PUNCH_L1_GR1_20240222163425_v1.fits"
 

--- a/punchbowl/level2/flow.py
+++ b/punchbowl/level2/flow.py
@@ -110,6 +110,7 @@ def level2_ctm_flow(data_list: list[str] | list[NDCube],
         data_list = [identify_bright_structures_task(cube, this_voter_filenames)
                      for cube, this_voter_filenames in zip(data_list, voter_filenames, strict=True)]
         output_data = merge_many_clear_task(data_list, trefoil_wcs)
+        output_data.meta["FILEVRSN"] = data_list[0].meta["FILEVRSN"].value
     else:
         output_dateobs = datetime.now(UTC).isoformat()
         output_datebeg = output_dateobs

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -1,4 +1,3 @@
-import time
 import multiprocessing as mp
 from datetime import UTC, datetime
 
@@ -39,14 +38,12 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
         Array of coefficients for solving polynomial
 
     """
-    logger = get_run_logger()
     c = np.transpose(input_vals)
     cube_is_good = np.isfinite(cube)
     num_inputs = np.sum(cube_is_good, axis=0)
 
     solution = np.zeros((input_vals.shape[1], cube.shape[1], cube.shape[2]))
     for i in range(cube.shape[1]):
-        start = time.time()
         for j in range(cube.shape[2]):
             is_good = cube_is_good[:, i, j]
             time_series = cube[:, i, j][is_good]
@@ -60,8 +57,6 @@ def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
                     solution[:, i, j] = solve_qp(g_iter, a, c_iter, time_series)[0]
                 except ValueError:
                     solution[:, i, j] = 0
-        end = time.time()
-        logger.info(f"{i} took {end - start} seconds")
     return np.asarray(solution), num_inputs
 
 
@@ -140,7 +135,6 @@ def _model_fcorona_for_cube_inner(xt: np.ndarray,
                                   clip_factor: float | None = 1,
                                   return_full_curves: bool=False,
                                   ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
-    logger = get_run_logger()
     cube[cube < min_brightness] = np.nan
     if clip_factor is not None:
         low, center, high = nan_percentile(cube, [25, 50, 75])
@@ -161,11 +155,7 @@ def _model_fcorona_for_cube_inner(xt: np.ndarray,
     if return_full_curves:
         return polynomial.polyval(xt, coefficients[::-1, :, :]).transpose((2, 0, 1)), counts, cube
 
-    start = time.time()
-    out = polynomial.polyval(reference_xt, coefficients[::-1, :, :]), counts
-    end = time.time()
-    logger.info(f"computed polyval in {end - start} seconds")
-    return out
+    return polynomial.polyval(reference_xt, coefficients[::-1, :, :]), counts
 
 
 def fill_nans_with_interpolation(image: np.ndarray) -> np.ndarray:

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -3,12 +3,14 @@ from datetime import UTC, datetime
 
 import astropy
 import numpy as np
+import scipy.optimize
 from dateutil.parser import parse as parse_datetime_str
 from ndcube import NDCube
 from numpy.polynomial import polynomial
 from prefect import get_run_logger
 from quadprog import solve_qp
 from scipy.interpolate import griddata
+from threadpoolctl import threadpool_limits
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.data.wcs import load_trefoil_wcs
@@ -67,6 +69,7 @@ def model_fcorona_for_cube(xt: np.ndarray,
                            clip_factor: float | None = 1,
                            return_full_curves: bool = False,
                            num_workers: int | None = 8,
+                           detrend: bool = True,
                            ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Model the F corona given a list of times and a corresponding data cube.
@@ -91,6 +94,8 @@ def model_fcorona_for_cube(xt: np.ndarray,
         frame is returned, producing a model at one instant in time.
     num_workers: int | None
         Work is parallelized over this many worker processes. If None, this matches the number of cores.
+    detrend : bool
+        Whether to detrend each time series before outlier rejection
 
     Returns
     -------
@@ -103,28 +108,38 @@ def model_fcorona_for_cube(xt: np.ndarray,
         The smoothed data cube. Returned only if return_full_curves is True.
 
     """
-    if num_workers < 2:
-        # Skip forking, reassembling, etc.
-        return _model_fcorona_for_cube_inner(xt, reference_xt, cube, min_brightness, clip_factor, return_full_curves)
-
+    stride = 32
     def args() -> tuple:
         # Generate a set of args for one task
-        for i in range(cube.shape[1]):
-            yield xt, reference_xt, cube[:, i:i + 1], min_brightness, clip_factor, return_full_curves
+        for i in range(0, cube.shape[0], stride):
+            for j in range(0, cube.shape[1], stride):
+                yield (xt, reference_xt, cube[i:i+stride, j:j+stride, :], min_brightness, clip_factor,
+                       return_full_curves, detrend)
 
-    with mp.Pool(processes=num_workers) as pool:
-        chunks = pool.starmap(_model_fcorona_for_cube_inner, args(), chunksize=10)
+    def reassemble(inputs: tuple) -> np.ndarray:
+        output = np.empty((cube.shape[0], cube.shape[1], *inputs[0].shape[2:]), dtype=inputs[0].dtype)
+        k = 0
+        for i in range(0, cube.shape[0], stride):
+            for j in range(0, cube.shape[1], stride):
+                output[i:i+stride, j:j+stride] = inputs[k]
+                k += 1
+        return output
+
+
+    # Since we're parallelizing with processes, we shouldn't run a lot of threads
+    with threadpool_limits(2), mp.Pool(processes=num_workers) as pool:
+        chunks = pool.starmap(_model_fcorona_for_cube_inner, args(), chunksize=4)
 
     # Combine the outputs of each task into final output arrays
     if return_full_curves:
         curves, counts, cubes = zip(*chunks, strict=False)
-        curves = np.concatenate(curves, axis=-2)
-        counts = np.concatenate(counts, axis=-2)
-        cubes = np.concatenate(cubes, axis=-2)
+        curves = reassemble(curves)
+        counts = reassemble(counts)
+        cubes = reassemble(cubes)
         return curves, counts, cubes
     model, counts = zip(*chunks, strict=False)
-    model = np.concatenate(model, axis=-2)
-    counts = np.concatenate(counts, axis=-2)
+    model = reassemble(model)
+    counts = reassemble(counts)
     return model, counts
 
 
@@ -134,26 +149,54 @@ def _model_fcorona_for_cube_inner(xt: np.ndarray,
                                   min_brightness: float = 1E-18,
                                   clip_factor: float | None = 1,
                                   return_full_curves: bool=False,
+                                  detrend: bool = True,
                                   ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
+    cube = cube.transpose((2, 0, 1))
     cube[cube < min_brightness] = np.nan
-    if clip_factor is not None:
-        low, center, high = nan_percentile(cube, [25, 50, 75])
-        width = high - low
-        a, b, c = np.where(cube[:, ...] > (center + (clip_factor * width)))
-        cube[a, b, c] = np.nan
-
-        a, b, c = np.where(cube[:, ...] < (center - (clip_factor * width)))
-        cube[a, b, c] = np.nan
-
     xt = np.array(xt)
     reference_xt -= xt[0]
     xt -= xt[0]
+
+    def trend_fcn(x: np.ndarray, xvals: np.ndarray) -> np.ndarray:
+        c0, c1, c2 = x
+        return c0 + c1 * xvals + c2 * xvals ** 2
+
+    def trend_resid(x: np.ndarray, xvals: np.ndarray, yvals: np.ndarray) -> np.ndarray:
+        return trend_fcn(x, xvals.ravel()) - yvals.ravel()
+
+    good_px = np.isfinite(cube)
+    if detrend:
+        if np.sum(good_px) < 20:
+            detrended_cube = cube
+        else:
+            x = np.broadcast_to(xt[:, None, None], cube.shape)
+            jacobian = np.stack((
+                    0*x[good_px].ravel() + 1,
+                    x[good_px],
+                    x[good_px] ** 2,
+                ), axis=1)
+            res = scipy.optimize.least_squares(trend_resid, (np.median(cube[good_px]), 0, 0), loss="cauchy",
+                                               f_scale=.5e-13, kwargs={"xvals": x[good_px], "yvals": cube[good_px]},
+                                               jac=lambda *a, **kw: jacobian) #noqa: ARG005
+            trend = trend_fcn(res.x, xt)
+            detrended_cube = cube - trend[:, None, None]
+    else:
+        detrended_cube = cube
+
+    if clip_factor is not None and np.any(good_px):
+        low, center, high = nan_percentile(detrended_cube, [25, 50, 75])
+        width = high - low
+        a, b, c = np.where(detrended_cube[:, ...] > (center + (clip_factor * width)))
+        cube[a, b, c] = np.nan
+
+        a, b, c = np.where(detrended_cube[:, ...] < (center - (clip_factor * width)))
+        cube[a, b, c] = np.nan
 
     input_array = np.c_[np.power(xt, 3), np.square(xt), xt, np.ones(len(xt))]
     coefficients, counts = solve_qp_cube(input_array, -cube)
     coefficients *= -1
     if return_full_curves:
-        return polynomial.polyval(xt, coefficients[::-1, :, :]).transpose((2, 0, 1)), counts, cube
+        return polynomial.polyval(xt, coefficients[::-1, :, :]), counts, cube.transpose((1, 2, 0))
 
     return polynomial.polyval(reference_xt, coefficients[::-1, :, :]), counts
 
@@ -216,7 +259,7 @@ def construct_f_corona_model(filenames: list[str],
     data_shape = (3, *trefoil_shape) if polarized else trefoil_shape
 
     number_of_data_frames = len(filenames)
-    data_cube = np.empty((number_of_data_frames, *data_shape), dtype=float)
+    data_cube = np.empty((*data_shape, number_of_data_frames), dtype=float)
 
     meta_list = []
     obs_times = []
@@ -226,7 +269,7 @@ def construct_f_corona_model(filenames: list[str],
     with mp.Pool(processes=num_workers) as pool:
         for i, (data, meta) in enumerate(pool.imap(_load_one_file, filenames)):
             dates.append(meta.datetime)
-            data_cube[i] = data
+            data_cube[..., i] = data
             obs_times.append(meta.datetime.timestamp())
             meta_list.append(meta)
     logger.info("ending data loading")

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 
 import numpy as np
 from ndcube import NDCube
@@ -67,7 +67,7 @@ def average_datetime(datetimes: list[datetime]) -> datetime:
     """Compute average datetime from a list of datetimes."""
     timestamps = [dt.timestamp() for dt in datetimes]
     average_timestamp = sum(timestamps) / len(timestamps)
-    return datetime.fromtimestamp(average_timestamp)  # noqa: DTZ006
+    return datetime.fromtimestamp(average_timestamp).astimezone(UTC)
 
 
 def _zvalue_from_index(arr, ind):  # noqa: ANN202, ANN001


### PR DESCRIPTION
## PR summary

- Detrending in F-corona estimation before outlier removal
- Read header values for gain and exposure time
- Enforce UTC for L2 date averaging, to avoid DST glitches
- Set FILEVRSN for L2s

