### PR TITLE
Adds NFI PCA filtering to LQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Supports floating-point COMPBITS values in https://github.com/punch-mission/punchbowl/pull/461
 - Adds data overview documentation in https://github.com/punch-mission/punchbowl/pull/458
 - Manages square root decoding table value overflow in https://github.com/punch-mission/punchbowl/pull/469
+- LQ PCA filtering, fix for NormalizedMetadata str values, and LQ FILEVRSN propagation in https://github.com/punch-mission/punchbowl/pull/472
 
 ## Version 0.0.12: May 12, 2025
 

--- a/punchbowl/data/meta.py
+++ b/punchbowl/data/meta.py
@@ -159,8 +159,6 @@ class MetaField:
             raise TypeError(msg)
         self._value = value
 
-
-
     @property
     def default(self) -> ValueType:
         """Get the default value."""
@@ -177,7 +175,8 @@ class MetaField:
     @staticmethod
     def _type_matches(value: ValueType, field_type: t.Any) -> bool:
         numpy_equivalents = {int: np.integer, float: np.floating}
-        if isinstance(value, field_type) or isinstance(value, numpy_equivalents[field_type]):  # noqa: SIM101
+        if (isinstance(value, field_type) or
+                (field_type in numpy_equivalents and isinstance(value, numpy_equivalents[field_type]))):
             return True
         return field_type is float and isinstance(value, int)
 

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -319,7 +319,8 @@ def _update_statistics(cube: NDCube) -> None:
     cube.meta["DATAMAX"] = float(np.nanmax(cube.data))
 
 
-def load_ndcube_from_fits(path: str | Path, key: str = " ", include_provenance: bool = True) -> NDCube:
+def load_ndcube_from_fits(path: str | Path, key: str = " ", include_provenance: bool = True,
+                          include_uncertainty: bool = True) -> NDCube:
     """Load an NDCube from a FITS file."""
     with warnings.catch_warnings(), fits.open(path) as hdul:
         warnings.filterwarnings(action="ignore", message=".*CROTA.*Human-readable solar north pole angle.*",
@@ -340,7 +341,7 @@ def load_ndcube_from_fits(path: str | Path, key: str = " ", include_provenance: 
         wcs = WCS(header, hdul, key=key)
         unit = u.ct
 
-        if len(hdul) >= 3 and isinstance(hdul[2], fits.hdu.CompImageHDU):
+        if include_uncertainty and len(hdul) >= 3 and isinstance(hdul[2], fits.hdu.CompImageHDU):
             secondary_hdu = hdul[2]
             uncertainty = _unpack_uncertainty(secondary_hdu.data.astype(float), data)
             uncertainty = StdDevUncertainty(uncertainty)

--- a/punchbowl/levelq/flow.py
+++ b/punchbowl/levelq/flow.py
@@ -54,6 +54,7 @@ def levelq_core_flow(data_list: list[str] | list[NDCube],
         output_data_mosaic.meta["DATE-OBS"] = output_dateobs
         output_data_mosaic.meta["DATE-BEG"] = output_datebeg
         output_data_mosaic.meta["DATE-END"] = output_dateend
+        output_data_mosaic.meta["FILEVRSN"] = ordered_data_list[0].meta["FILEVRSN"].value
         output_data_mosaic = set_spacecraft_location_to_earth(output_data_mosaic)
 
         output_meta_nfi = NormalizedMetadata.load_template("CNN", "Q")
@@ -69,6 +70,7 @@ def levelq_core_flow(data_list: list[str] | list[NDCube],
         output_data_nfi.meta["DATE-OBS"] = output_dateobs_nfi
         output_data_nfi.meta["DATE-BEG"] = output_datebeg_nfi
         output_data_nfi.meta["DATE-END"] = output_dateend_nfi
+        output_data_nfi.meta["FILEVRSN"] = ordered_data_list[0].meta["FILEVRSN"].value
         output_data_nfi = set_spacecraft_location_to_earth(output_data_nfi)
     else:
         output_dateobs = datetime.now(UTC).isoformat()

--- a/punchbowl/levelq/pca.py
+++ b/punchbowl/levelq/pca.py
@@ -34,13 +34,14 @@ def pca_filter(input_cube: NDCube, files_to_fit: list[NDCube | Callable | str],
         pca.fit(all_files_to_fit.reshape((len(all_files_to_fit), -1)))
         logger.info("Fitting finished")
 
+        transformed = pca.transform(input_cube.data.reshape((1, -1)))
+
         if med_filt:
             for i in range(len(pca.components_)):
                 comp = pca.components_[i].reshape(input_cube.data.shape)
                 comp = scipy.signal.medfilt2d(comp, med_filt)
                 pca.components_[i] = comp.ravel()
-        logger.info("Median smoothing finished finished")
+            logger.info("Median smoothing finished")
 
-        transformed = pca.transform(input_cube.data.reshape((1, -1)))
         reconstructed = pca.inverse_transform(transformed).reshape(input_cube.data.shape)
         input_cube.data -= reconstructed

--- a/punchbowl/levelq/pca.py
+++ b/punchbowl/levelq/pca.py
@@ -1,0 +1,46 @@
+from collections.abc import Callable
+
+import numpy as np
+import scipy.signal
+from ndcube import NDCube
+from prefect import get_run_logger
+from sklearn.decomposition import PCA
+from threadpoolctl import threadpool_limits
+
+from punchbowl.prefect import punch_task
+from punchbowl.util import load_image_task
+
+
+@punch_task()
+def pca_filter(input_cube: NDCube, files_to_fit: list[NDCube | Callable | str],
+               n_components: int=50, med_filt: int=5) -> None:
+    """Run PCA-based filtering."""
+    logger = get_run_logger()
+    all_files_to_fit = np.empty((len(files_to_fit), *input_cube.data.shape), dtype=input_cube.data.dtype)
+    for i, input_file in enumerate(files_to_fit):
+        if isinstance(input_file, NDCube):
+            all_files_to_fit[i] = input_file.data
+        elif isinstance(input_file, str):
+            all_files_to_fit[i] = load_image_task(input_file, include_provenance=False, include_uncertainty=False).data
+        elif isinstance(input_file, Callable):
+            input_file(all_files_to_fit[i])
+        else:
+            raise TypeError(f"Invalid type {type(input_file)} for input file")
+    logger.info(
+        f"Loaded {len(all_files_to_fit)} images to fit; filling {all_files_to_fit.nbytes/1024**3:.2f} GB")
+
+    with threadpool_limits(30):
+        pca = PCA(n_components=n_components)
+        pca.fit(all_files_to_fit.reshape((len(all_files_to_fit), -1)))
+        logger.info("Fitting finished")
+
+        if med_filt:
+            for i in range(len(pca.components_)):
+                comp = pca.components_[i].reshape(input_cube.data.shape)
+                comp = scipy.signal.medfilt2d(comp, med_filt)
+                pca.components_[i] = comp.ravel()
+        logger.info("Median smoothing finished finished")
+
+        transformed = pca.transform(input_cube.data.reshape((1, -1)))
+        reconstructed = pca.inverse_transform(transformed).reshape(input_cube.data.shape)
+        input_cube.data -= reconstructed

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -45,7 +45,7 @@ def output_image_task(data: NDCube, output_filename: str) -> None:
 
 
 @punch_task
-def load_image_task(input_filename: str) -> NDCube:
+def load_image_task(input_filename: str, include_provenance: bool = True, include_uncertainty: bool = True) -> NDCube:
     """
     Prefect task to load data for processing.
 
@@ -53,6 +53,10 @@ def load_image_task(input_filename: str) -> NDCube:
     ----------
     input_filename : str
         path to file to load
+    include_provenance : bool
+        whether to load the provenance layer
+    include_uncertainty : bool
+        whether to load the uncertainty layer
 
     Returns
     -------
@@ -60,7 +64,8 @@ def load_image_task(input_filename: str) -> NDCube:
         loaded version of the image
 
     """
-    return load_ndcube_from_fits(input_filename)
+    return load_ndcube_from_fits(
+        input_filename, include_provenance=include_provenance, include_uncertainty=include_uncertainty)
 
 
 def average_datetime(datetimes: list[datetime]) -> datetime:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
         "numexpr",
         "glymur",
         "astroscrappy",
+        "scikit-learn",
 ]
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## PR summary

Adds NFI PCA filtering to LQ, and some changes to support it:

- When we're loading the thousand files to be fit, we don't need to spend time loading uncertainty or provenance
- Copy `FILEVRSN` from one of the input files into the LQ output
- Fix for `NormalizedMetadata` having strings inserted

## Test plan

It runs on 190