### PR TITLE
For pointing refinement, we restrict the nfi mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Also available in GitHub](https://github.com/punch-mission/punchbowl/releases)
 
+## Unreleased
+
+- Restricts the mask for NFI pointing refinement in https://github.com/punch-mission/punchbowl/pull/486
+
 ## Version 0.0.14: June 3, 2025
 
 - Adds DOI for level 0 data products in https://github.com/punch-mission/punchbowl/pull/481

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -233,9 +233,10 @@ def levelh_core_flow(
             def alignment_mask(x:float, y:float) -> float:
                 return (x > 100) * (x < 1900) * (y > 250) * (y < 1900)
         else:
-            def alignment_mask(x:float, y:float) -> float:
-                return ((x < 824) + (x > 1224)) * ((y < 824) + (y > 1224)) * \
-                    (x > 100) * (x < 1900) * (y > 100) * (y < 1900)
+            def alignment_mask(x: float, y: float) -> bool:
+                r = np.sqrt((x - 1024) ** 2 + (y - 1024) ** 2)
+                theta = np.rad2deg(np.arctan2(y - 1024, x - 1024)) + 180
+                return (r > 250) * (r < 950) * ((theta < 25) + (theta > 155))
         data = align_task(data, mask=alignment_mask)
 
         # Repackage data with proper metadata


### PR DESCRIPTION
Makes the NFI mask avoid the occulter, outer edge, and pylon glint area for pointing refinement. 