### PR TITLE
Don't copy certain meta keys from L0 to L1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Relabels CCD halves in https://github.com/punch-mission/punchbowl/pull/493
 - Adds documentation for data versions and anomalies in https://github.com/punch-mission/punchbowl/pull/495
+- Avoid incorrectly coping some metadata from L0 to L1 in https://github.com/punch-mission/punchbowl/pull/508
 
 ## Version 0.0.15: June 4, 2025
 

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -169,6 +169,8 @@ def level1_core_flow(  # noqa: C901
         new_meta = NormalizedMetadata.load_template(product_code, "1")
         # copy over the existing values
         for key in data.meta.keys(): # noqa: SIM118
+            if key in ["BUNIT", "DESCRPTN", "FILENAME", "ISSQRT", "LEVEL", "TITLE"]:
+                continue
             if key in new_meta.keys(): # noqa: SIM118
                 new_meta[key] = data.meta[key].value
         new_meta.history = data.meta.history
@@ -187,7 +189,6 @@ def level1_core_flow(  # noqa: C901
         if isinstance(quartic_coefficient_path, Callable):
             _, quartic_coefficient_path = quartic_coefficient_path()
         new_meta["CALCF"] = os.path.basename(quartic_coefficient_path) if quartic_coefficient_path else ""
-        new_meta["LEVEL"] = "1"
         new_meta["FILEVRSN"] = data.meta["FILEVRSN"].value
 
         data = NDCube(data=data.data, meta=new_meta, wcs=data.wcs, unit=data.unit, uncertainty=data.uncertainty)


### PR DESCRIPTION
## PR summary

We were copying a lot of data from the L0 headers into the L1 headers, but some of that should have been left behind. We were generating L1s with `TITLE   = 'PUNCH Level-0 NFI-0 Clear Image'`, `BUNIT   = 'sqrt(DN)'`, etc. (This was overriding the correct default in the L1 omniheader.)

These are just the keys that stood out to me, it's possible there are more we shouldn't copy.

Closes #504