### PR TITLE
Remove unused prefect test decorator

### DIFF
--- a/punchbowl/level1/tests/test_stray_light.py
+++ b/punchbowl/level1/tests/test_stray_light.py
@@ -13,7 +13,6 @@ from punchbowl.level1.stray_light import remove_stray_light_task
 
 THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
-@pytest.mark.prefect_test()
 def test_check_calibration_time_delta_warning(sample_ndcube) -> None:
     """
     If the time between the data of interest and the calibration file is too great, then a warning is raised.
@@ -29,7 +28,6 @@ def test_check_calibration_time_delta_warning(sample_ndcube) -> None:
             assert isinstance(corrected_punchdata, NDCube)
 
 
-@pytest.mark.prefect_test()
 def test_no_straylight_file(sample_ndcube) -> None:
     """
     An invalid vignetting file should be provided. Check that an error is raised.

--- a/punchbowl/level1/tests/test_vignette.py
+++ b/punchbowl/level1/tests/test_vignette.py
@@ -17,7 +17,6 @@ from punchbowl.level1.vignette import correct_vignetting_task
 THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
 
-@pytest.mark.prefect_test()
 def test_check_calibration_time_delta_warning(sample_ndcube) -> None:
     """
     If the time between the data of interest and the calibration file is too great, then a warning is raised.
@@ -33,7 +32,6 @@ def test_check_calibration_time_delta_warning(sample_ndcube) -> None:
             assert isinstance(corrected_punchdata, NDCube)
 
 
-@pytest.mark.prefect_test()
 def test_no_vignetting_file(sample_ndcube) -> None:
     """
     An invalid vignetting file should be provided. Check that an error is raised.
@@ -48,7 +46,6 @@ def test_no_vignetting_file(sample_ndcube) -> None:
         assert corrected_punchdata.meta.history[0].comment == 'Vignetting skipped'
 
 
-@pytest.mark.prefect_test()
 def test_invalid_vignetting_file(sample_ndcube) -> None:
     """
     An invalid vignetting file should be provided. Check that an error is raised.
@@ -62,7 +59,6 @@ def test_invalid_vignetting_file(sample_ndcube) -> None:
             corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
 
 
-@pytest.mark.prefect_test()
 def test_invalid_polarization_state(sample_ndcube) -> None:
     """
     Check that a mismatch between polarization states in the vignetting function and data raises an error.
@@ -77,7 +73,6 @@ def test_invalid_polarization_state(sample_ndcube) -> None:
             assert isinstance(corrected_punchdata, NDCube)
 
 
-@pytest.mark.prefect_test()
 def test_invalid_telescope(sample_ndcube) -> None:
     """
     Check that a mismatch between telescopes in the vignetting function and data raises an error.
@@ -93,7 +88,6 @@ def test_invalid_telescope(sample_ndcube) -> None:
             assert isinstance(corrected_punchdata, NDCube)
 
 
-@pytest.mark.prefect_test()
 def test_invalid_data_file(sample_ndcube) -> None:
     """
     An invalid vignetting file should be provided. Check that an error is raised.
@@ -107,7 +101,6 @@ def test_invalid_data_file(sample_ndcube) -> None:
             corrected_punchdata = correct_vignetting_task.fn(sample_data, vignetting_filename)
 
 
-@pytest.mark.prefect_test()
 def test_vignetting_correction(sample_ndcube) -> None:
     """
     A valid vignetting file should be provided. Check that a corrected PUNCHData object is generated.

--- a/punchbowl/level2/tests/test_polarization.py
+++ b/punchbowl/level2/tests/test_polarization.py
@@ -34,7 +34,6 @@ def test_resolve_polarization(sample_data_triplet):
     assert all(isinstance(output_punchdata, NDCube) for output_punchdata in output_punchdata_list)
 
 
-@pytest.mark.prefect_test
 def test_resolve_polarization_task(sample_data_triplet):
     """
     Test the resolve polarization prefect flow using a test harness


### PR DESCRIPTION
This is the first of many pull requests to clean up test warnings. This resolves that the prefect test label isn't used anymore. 