### PR TITLE
Reduce memory use of stray light model generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Adds a quickfix for parsing input filenames for the calibration CLI tool in https://github.com/punch-mission/punchbowl/pull/516
 - Adds docstring to PSF function in https://github.com/punch-mission/punchbowl/pull/519
+- Reduces memory usage of stray light model generation in https://github.com/punch-mission/punchbowl/pull/525
 
 ## Version 0.0.16: July 3, 2025
 

--- a/punchbowl/level1/stray_light.py
+++ b/punchbowl/level1/stray_light.py
@@ -13,14 +13,14 @@ from punchbowl.exceptions import (
     InvalidDataError,
     LargeTimeDeltaWarning,
 )
-from punchbowl.prefect import punch_task
+from punchbowl.prefect import punch_flow, punch_task
 from punchbowl.util import nan_percentile
 
 
-def estimate_stray_light(
-        filepaths: list[str],
-        percentile: float = 3,
-        do_uncertainty: bool = True) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+@punch_flow
+def estimate_stray_light(filepaths: list[str],
+                         percentile: float = 3,
+                         do_uncertainty: bool = True) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Estimate the fixed stray light pattern using a percentile."""
     data = None
     uncertainties = None


### PR DESCRIPTION
## PR summary

This cuts the memory use of the stray light model generation by not keeping the `NDCube`s in memory in addition to the large data cube that stores all the images.