### PR TITLE
Add button to view source in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Also available in GitHub](https://github.com/punch-mission/punchbowl/releases)
 
+## Latest - Unreleased
+
+- Adds docs button to view source in https://github.com/punch-mission/punchbowl/pull/526
+
 ## Version 0.0.16: July 3, 2025
 
 - Fixed vignetting docstring in https://github.com/punch-mission/punchbowl/pull/510

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ copy_and_truncate_csv(src_csv_path, dest_csv_path, columns_to_include, filter_co
 
 extensions = ["autoapi.extension",
               "sphinx.ext.autodoc",
+              "sphinx.ext.viewcode",
               "sphinx.ext.napoleon",
               "sphinx_rtd_theme",
               "sphinx_favicon",


### PR DESCRIPTION
It's as simple as enabling a Sphinx extension, so I did it. 

- [x] add changelog