### PR TITLE
Make stray light run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Latest - Unreleased
 - Adds uncertainty to test NDCube write and read in https://github.com/punch-mission/punchbowl/pull/535
+- Use a full, valid WCS for stray light models in https://github.com/punch-mission/punchbowl/pull/537
 
 ## Version 0.0.17: July 23, 2025
 

--- a/punchbowl/level1/stray_light.py
+++ b/punchbowl/level1/stray_light.py
@@ -18,7 +18,7 @@ def estimate_stray_light(filepaths: list[str],
     """Estimate the fixed stray light pattern using a percentile."""
     data = None
     uncertainties = None
-    for i, path in enumerate(filepaths):
+    for i, path in enumerate(sorted(filepaths)):
         cube = load_ndcube_from_fits(path, include_provenance=False, include_uncertainty=do_uncertainty)
         if i == 0:
             first_meta = cube.meta

--- a/punchbowl/level1/stray_light.py
+++ b/punchbowl/level1/stray_light.py
@@ -3,7 +3,6 @@ import pathlib
 import warnings
 
 import numpy as np
-from astropy.wcs import WCS
 from ndcube import NDCube
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
@@ -48,7 +47,7 @@ def estimate_stray_light(filepaths: list[str],
 
     uncertainty = np.sqrt(np.sum(uncertainties ** 2, axis=0)) / len(filepaths) if do_uncertainty else None
 
-    out_cube = NDCube(data=stray_light_estimate, meta=meta, wcs=WCS(naxis=2), uncertainty=uncertainty)
+    out_cube = NDCube(data=stray_light_estimate, meta=meta, wcs=cube.wcs, uncertainty=uncertainty)
 
     return [out_cube]
 

--- a/punchbowl/level1/stray_light.py
+++ b/punchbowl/level1/stray_light.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from ndcube import NDCube
+from prefect import get_run_logger
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits
 from punchbowl.exceptions import IncorrectPolarizationStateWarning, IncorrectTelescopeWarning, InvalidDataError
@@ -16,6 +17,8 @@ def estimate_stray_light(filepaths: list[str],
                          percentile: float = 1,
                          do_uncertainty: bool = True) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Estimate the fixed stray light pattern using a percentile."""
+    logger = get_run_logger()
+    logger.info(f"Running with {len(filepaths)} input files")
     data = None
     uncertainties = None
     for i, path in enumerate(sorted(filepaths)):
@@ -34,6 +37,8 @@ def estimate_stray_light(filepaths: list[str],
                 uncertainties[i] = cube.uncertainty.array
             else:
                 uncertainties[i] = np.zeros_like(cube.data)
+
+    logger.info(f"Images loaded; they span {first_meta['DATE-OBS'].value} to {last_meta['DATE-OBS'].value}")
 
     stray_light_estimate = nan_percentile(data, percentile).squeeze()
 


### PR DESCRIPTION
Outside my notebook, we can't easily set the `write_ndcube_to_fits` flag to avoid computing a celestial WCS, so let's just use a full but arbitrary WCS for now.