### PR TITLE
Improvement of testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ docs/_build/
 *.DS_Store
 *.npy
 test_run/
+PUNCH_SAMPLE/

--- a/changelog/546.bugfix.rst
+++ b/changelog/546.bugfix.rst
@@ -1,0 +1,1 @@
+Skips PCA testing on macOS and improves git handling of test temporary sample files.

--- a/punchbowl/levelq/tests/test_pca.py
+++ b/punchbowl/levelq/tests/test_pca.py
@@ -1,5 +1,8 @@
+import sys
+
 import numpy as np
 import prefect.logging
+import pytest
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs import WCS
 from ndcube import NDCube
@@ -32,6 +35,7 @@ def test_find_bodies_in_image_quarters():
     assert np.all(np.array(result) == False)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Skipping PCA test on macOS.")
 def test_that_pca_filter_runs():
     cubes = []
 


### PR DESCRIPTION
Ignores PCA testing on macOS (which is doomed to fail) and commands git to ignore sample PUNCH data downloaded as part of testing.