### PR TITLE
Change NFI pointing alignment to work differently than WFI

### DIFF
--- a/changelog/557.bugfix.rst
+++ b/changelog/557.bugfix.rst
@@ -1,0 +1,1 @@
+NFI pointing was consistently failing. This improves it by changing the alignment search parameters and allowing astrometry.net to fail by falling back on the spacecraft WCS. 

--- a/changelog/557.bugfix.rst
+++ b/changelog/557.bugfix.rst
@@ -1,1 +1,1 @@
-NFI pointing was consistently failing. This improves it by changing the alignment search parameters and allowing astrometry.net to fail by falling back on the spacecraft WCS. 
+NFI pointing was consistently failing. This improves it by changing the alignment search parameters and allowing astrometry.net to fail by falling back on the spacecraft WCS.


### PR DESCRIPTION
NFI pointing alignment was failing because of astrometry.net's initial solver. This was in part to incorrect search scales and also because of weird "non-stars" being detected as stars. We now try to use astrometry.net but if it fails we warn and proceed with the instrument WCS. 