### PR TITLE
Turns off ruff EM101

### DIFF
--- a/changelog/558.trivial.rst
+++ b/changelog/558.trivial.rst
@@ -1,0 +1,1 @@
+Turns off ruff's EM101 check.

--- a/punchbowl/data/wcs.py
+++ b/punchbowl/data/wcs.py
@@ -163,7 +163,7 @@ def get_p_angle(time: str="now") -> u.deg:
 def hpc_to_gcrs(HPcoord, GCRSframe):  # noqa: ANN201, N803, ANN001
     """Convert helioprojective to GCRS."""
     if not _times_are_equal(HPcoord.obstime, GCRSframe.obstime):
-        raise ValueError("Obstimes are not equal")  # noqa: EM101
+        raise ValueError("Obstimes are not equal")
     obstime = HPcoord.obstime or GCRSframe.obstime
 
     # Compute the three angles we need
@@ -221,7 +221,7 @@ def hpc_to_gcrs(HPcoord, GCRSframe):  # noqa: ANN201, N803, ANN001
 def gcrs_to_hpc(GCRScoord, Helioprojective): # noqa: ANN201, N803, ANN001
     """Convert GCRS to HPC."""
     if not _times_are_equal(GCRScoord.obstime, Helioprojective.obstime):
-        raise ValueError("Obstimes are not equal")  # noqa: EM101
+        raise ValueError("Obstimes are not equal")
     obstime = GCRScoord.obstime or Helioprojective.obstime
 
     # Compute the three angles we need

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ lint.ignore = [
     "TC002",
     "TC003",
     "E731",
+    "EM101"
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Stop requiring error messages to be defined separately