### PR TITLE
Update input types for LQ CTM

### DIFF
--- a/changelog/563.bugfix.rst
+++ b/changelog/563.bugfix.rst
@@ -1,0 +1,1 @@
+Fix LQ CTM to run from Q* input files.

--- a/punchbowl/levelq/flow.py
+++ b/punchbowl/levelq/flow.py
@@ -15,7 +15,7 @@ from punchbowl.level2.resample import reproject_many_flow
 from punchbowl.levelq.pca import pca_filter
 from punchbowl.util import DataLoader, average_datetime, find_first_existing_file, load_image_task, output_image_task
 
-ORDER_QP = ["CR1", "CR2", "CR3", "CNN"]
+ORDER_QP = ["QR1", "QR2", "QR3", "CNN"]
 
 @flow(validate_parameters=False)
 def levelq_CNN_core_flow(data_list: list[str] | list[NDCube], #noqa: N802


### PR DESCRIPTION
## PR summary

It needs to know it's getting Q file inputs now. This runs successfully on 190.