### PR TITLE
Don't crash on import if Prefect can't be reached

### DIFF
--- a/changelog/706.bugfix.rst
+++ b/changelog/706.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for possible crash on import if a Prefect server isn't running.

--- a/punchbowl/data/tests/test_punch_io.py
+++ b/punchbowl/data/tests/test_punch_io.py
@@ -30,7 +30,7 @@ SAMPLE_SPACECRAFT_DEF_PATH = os.path.join(TESTDATA_DIR, "spacecraft.yaml")
 
 @pytest.fixture
 def sample_ndcube():
-    def _sample_ndcube(shape, code="PM1", level="0", date_obs=None):
+    def _sample_ndcube(shape, code="PM1", level="0", date_obs=None, crota=0):
         data = np.random.random(shape).astype(np.float32)
         uncertainty = StdDevUncertainty(np.sqrt(np.abs(data)))
         wcs = WCS(naxis=2)
@@ -41,7 +41,7 @@ def sample_ndcube():
         wcs.wcs.crval = 1, 1
         wcs.wcs.cname = "HPC lon", "HPC lat"
         # For polarized static stray light estimation, which currently excludes northern images
-        wcs.wcs.pc = calculate_pc_matrix(90 * np.pi / 180, (0.1, 0.1))
+        wcs.wcs.pc = calculate_pc_matrix(crota * np.pi / 180, (0.1, 0.1))
 
         if level in ["2", "3"] and code[0] == "P":
             wcs = add_stokes_axis_to_wcs(wcs, 2)

--- a/punchbowl/level1/tests/test_stray_light.py
+++ b/punchbowl/level1/tests/test_stray_light.py
@@ -12,6 +12,7 @@ from prefect.logging import disable_run_logger
 
 from punchbowl.data import NormalizedMetadata, punch_io, write_ndcube_to_fits
 from punchbowl.data.tests.test_punch_io import sample_ndcube
+from punchbowl.data.wcs import calculate_pc_matrix
 from punchbowl.level1.stray_light import estimate_polarized_stray_light, estimate_stray_light, remove_stray_light_task
 
 THIS_DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -61,6 +62,7 @@ def dummy_fits_paths(tmp_path: Path):
     wcs.wcs.cdelt = 0.01, 0.01
     wcs.wcs.crpix = 1024, 1024
     wcs.wcs.crval = 0, 0
+    wcs.wcs.pc = calculate_pc_matrix(90 * np.pi / 180, (0.01, 0.01))
     wcs.wcs.cname = "HPC lon", "HPC lat"
     wcs.array_shape = (2048, 2048)
 
@@ -91,9 +93,9 @@ def test_estimate_polarized_stray_light(dummy_fits_paths) -> None:
 
 def test_estimate_polarized_stray_light_runs(tmpdir, sample_ndcube):
     dates = [datetime(2025, 1, d, 1, 2, 3).strftime('%Y-%m-%dT%H:%M:%S') for d in range(1, 11)]
-    m_cubes = [sample_ndcube(shape=(10, 10), code='XM1', level="1", date_obs=date) for date in dates]
-    z_cubes = [sample_ndcube(shape=(10, 10), code='XZ1', level="1", date_obs=date) for date in dates]
-    p_cubes = [sample_ndcube(shape=(10, 10), code='XP1', level="1", date_obs=date) for date in dates]
+    m_cubes = [sample_ndcube(shape=(10, 10), code='XM1', level="1", date_obs=date, crota=90) for date in dates]
+    z_cubes = [sample_ndcube(shape=(10, 10), code='XZ1', level="1", date_obs=date, crota=90) for date in dates]
+    p_cubes = [sample_ndcube(shape=(10, 10), code='XP1', level="1", date_obs=date, crota=90) for date in dates]
 
     mpaths, zpaths, ppaths = [], [], []
     for i, cube in enumerate(m_cubes):

--- a/punchbowl/levelq/tests/test_flow.py
+++ b/punchbowl/levelq/tests/test_flow.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 from ndcube import NDCube
 from prefect.logging import disable_run_logger
@@ -7,10 +8,39 @@ from prefect.testing.utilities import prefect_test_harness
 from punchbowl.data.punch_io import write_ndcube_to_fits
 from punchbowl.data.tests.test_punch_io import sample_ndcube
 from punchbowl.data.wcs import load_trefoil_wcs
-from punchbowl.levelq.flow import levelq_CTM_core_flow
+from punchbowl.levelq.flow import levelq_CQM_core_flow, levelq_CTM_core_flow
 
 
 def test_ctm_flow_runs_with_filenames(sample_ndcube, tmpdir):
+    input_image = sample_ndcube(shape=(10, 10), code='CQM', level="Q", date_obs='2025-01-03 00:00:00')
+    input_image.meta['HAS_WFI1'].value = 1
+    input_image.meta['HAS_WFI2'].value = 1
+    input_image.meta['HAS_WFI3'].value = 1
+    input_image.meta['HAS_NFI4'].value = 1
+    fcorona_before = sample_ndcube(shape=(10, 10), code="CFM", level="Q", date_obs='2025-01-02 00:00:00')
+    fcorona_after = sample_ndcube(shape=(10, 10), code="CFM", level="Q", date_obs='2025-01-04 00:00:00')
+
+    paths = []
+    for i, cube in enumerate([input_image, fcorona_before, fcorona_after]):
+        path = os.path.join(tmpdir, f"test_input_{i}.fits")
+        write_ndcube_to_fits(cube, path)
+        paths.append(path)
+
+    trefoil_wcs, _ = load_trefoil_wcs()
+    with prefect_test_harness(), disable_run_logger():
+        output = levelq_CTM_core_flow.fn([paths[0]],
+                                         before_f_corona_model_path=paths[1],
+                                         after_f_corona_model_path=paths[2]                                         )
+    assert isinstance(output[0], NDCube)
+    assert output[0].meta["TYPECODE"].value == "CT"
+
+    assert output[0].meta["HAS_WFI1"].value == 1
+    assert output[0].meta["HAS_WFI2"].value == 1
+    assert output[0].meta["HAS_WFI3"].value == 1
+    assert output[0].meta["HAS_NFI4"].value == 1
+
+
+def test_cqm_flow_runs_with_filenames(sample_ndcube, tmpdir):
     data_list = [sample_ndcube(shape=(10, 10), code=code, level="1") for code in ["QR1", "QR2", "QR3"]]
     data_list.append(sample_ndcube(shape=(10, 10), code="CNN", level="Q"))
 
@@ -22,9 +52,9 @@ def test_ctm_flow_runs_with_filenames(sample_ndcube, tmpdir):
 
     trefoil_wcs, _ = load_trefoil_wcs()
     with prefect_test_harness(), disable_run_logger():
-        output = levelq_CTM_core_flow.fn(paths, trefoil_wcs=trefoil_wcs[::8, ::8], trefoil_shape=(512, 512))
+        output = levelq_CQM_core_flow.fn(paths, trefoil_wcs=trefoil_wcs[::8, ::8], trefoil_shape=(512, 512))
     assert isinstance(output[0], NDCube)
-    assert output[0].meta["TYPECODE"].value == "CT"
+    assert output[0].meta["TYPECODE"].value == "CQ"
 
     assert output[0].meta["HAS_WFI1"].value == 1
     assert output[0].meta["HAS_WFI2"].value == 1

--- a/punchbowl/prefect.py
+++ b/punchbowl/prefect.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from httpx import ConnectError
 from ndcube import NDCube
 from prefect import Flow, Task, flow, get_run_logger, task
 from prefect.cache_policies import NO_CACHE
@@ -28,7 +29,10 @@ def completion_debugger(task: Task, task_run: TaskRun, state: State) -> None:
 def failure_hook(task: Task, task_run: TaskRun, state: State) -> None:
     """Run if a punch_task fails."""
 
-_debug_mode = Variable.get("debug", False)
+try:
+    _debug_mode = Variable.get("debug", False)
+except ConnectError:
+    _debug_mode = False
 
 def punch_task(*args: Any, **kwargs: Any) -> Task:
     """Prefect task that does PUNCH special things."""


### PR DESCRIPTION
The `hasten-db` tests are now failing in CI but not locally. It's failing with a "can't reach ephemeral Prefect server` error that traces back to this line. If I run locally without Prefect running I get a different error on this line, and this change stops it, so let's see if this helps CI?

Not sure why this wasn't a problem before...