### PR TITLE
Allows Prefect debug mode to be unreachable due to runtime error

### DIFF
--- a/changelog/707.bugfix.rst
+++ b/changelog/707.bugfix.rst
@@ -1,0 +1,1 @@
+Prefect can fail to be reached due to Runtime error.

--- a/punchbowl/prefect.py
+++ b/punchbowl/prefect.py
@@ -31,7 +31,7 @@ def failure_hook(task: Task, task_run: TaskRun, state: State) -> None:
 
 try:
     _debug_mode = Variable.get("debug", False)
-except ConnectError:
+except (ConnectError, RuntimeError):
     _debug_mode = False
 
 def punch_task(*args: Any, **kwargs: Any) -> Task:


### PR DESCRIPTION
I found in my tests that the prefect debug mode problem was also being triggered by runtime errors. 

We catch this here because if Prefect isn't available we assume we're not in debug mode. It makes the tests run smoother.
