### PR TITLE
Exclude bad-packet images from certain steps

### DIFF
--- a/changelog/782.bugfix.rst
+++ b/changelog/782.bugfix.rst
@@ -1,0 +1,1 @@
+Exclude bad-packet images from certain steps.

--- a/punchbowl/level1/despike.py
+++ b/punchbowl/level1/despike.py
@@ -137,7 +137,10 @@ def despike_polseq_task(data_object: NDCube,
 
     neighbors = neighbors if neighbors is not None else []
 
-    if 3 <= len(neighbors) <= 7:
+    if data_object.meta['BADPKTS'].value:
+        data_object.meta.history.add_now("LEVEL1-despike", "Image has bad packets; no despiking applied")
+        logger.info(f"Bad packets---despiking skipped")
+    elif 3 <= len(neighbors) <= 7:
         logger.info(f"Neighbors = {neighbors}")
 
         neighbors = [load_ndcube_from_fits(n) if isinstance(n, str) else n for n in neighbors]

--- a/punchbowl/level1/despike.py
+++ b/punchbowl/level1/despike.py
@@ -137,10 +137,7 @@ def despike_polseq_task(data_object: NDCube,
 
     neighbors = neighbors if neighbors is not None else []
 
-    if data_object.meta['BADPKTS'].value:
-        data_object.meta.history.add_now("LEVEL1-despike", "Image has bad packets; no despiking applied")
-        logger.info(f"Bad packets---despiking skipped")
-    elif 3 <= len(neighbors) <= 7:
+    if 3 <= len(neighbors) <= 7:
         logger.info(f"Neighbors = {neighbors}")
 
         neighbors = [load_ndcube_from_fits(n) if isinstance(n, str) else n for n in neighbors]

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -289,7 +289,11 @@ def level1_late_core_flow( # noqa: C901
 
         data = correct_psf_task(data, psf_model_path, max_workers=max_workers)
         if do_align:
-            data = align_task(data, distortion_path)
+            if data.meta["BADPKTS"].value:
+                data.meta.history.add_now("LEVEL1-align", "Image has bad packets; no alignment applied")
+                logger.info("Bad packets---alignment skipped")
+            else:
+                data = align_task(data, distortion_path)
 
         if mask is not None:
             data.data[~mask] = 0

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -87,7 +87,12 @@ def level1_early_core_flow(  # noqa: C901
         if data.meta["ISSQRT"].value:
             data = decode_sqrt_data(data)
 
-        saturated_pixels = data.data >= data.meta["DSATVAL"].value
+        if l0_data.meta['BADPKTS'].value:
+            data.meta.history.add_now("LEVEL1", "Image has bad packets; saturated pixels not filled")
+            logger.info(f"Bad packets---not filling saturated pixels")
+            saturated_pixels = None
+        else:
+            saturated_pixels = data.data >= data.meta["DSATVAL"].value
         data = update_initial_uncertainty_task(data,
                                                dark_level=dark_level,
                                                gain_bottom=gain_bottom,

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -127,11 +127,15 @@ def level1_early_core_flow(  # noqa: C901
         data.data[:, :] = np.clip(dn_to_msb(data.data[:, :], data.wcs, **scaling), a_min=0, a_max=None)
         data.uncertainty.array[:, :] = dn_to_msb(data.uncertainty.array[:, :], data.wcs, **scaling)
 
-        data = destreak_task(data,
-                             exposure_time=exposure_time,
-                             reset_line_time=reset_line_time,
-                             readout_line_time=readout_line_time,
-                             max_workers=max_workers)
+        if l0_data.meta['BADPKTS'].value:
+            data.meta.history.add_now("LEVEL1-destreak", "Image has bad packets; no destreaking applied")
+            logger.info(f"Bad packets---destreaking skipped")
+        else:
+            data = destreak_task(data,
+                                 exposure_time=exposure_time,
+                                 reset_line_time=reset_line_time,
+                                 readout_line_time=readout_line_time,
+                                 max_workers=max_workers)
         data = correct_vignetting_task(data, vignetting_function_path, second_vignetting_function_path,
                                        allow_extrapolation=False)
         data = remove_deficient_pixels_task(data,

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -87,9 +87,9 @@ def level1_early_core_flow(  # noqa: C901
         if data.meta["ISSQRT"].value:
             data = decode_sqrt_data(data)
 
-        if l0_data.meta['BADPKTS'].value:
+        if l0_data.meta["BADPKTS"].value:
             data.meta.history.add_now("LEVEL1", "Image has bad packets; saturated pixels not filled")
-            logger.info(f"Bad packets---not filling saturated pixels")
+            logger.info("Bad packets---not filling saturated pixels")
             saturated_pixels = None
         else:
             saturated_pixels = data.data >= data.meta["DSATVAL"].value
@@ -101,9 +101,9 @@ def level1_early_core_flow(  # noqa: C901
                                                bitrate_signal=bitrate_signal,
                                                saturated_pixels=saturated_pixels,
                                                )
-        if l0_data.meta['BADPKTS'].value:
+        if l0_data.meta["BADPKTS"].value:
             data.meta.history.add_now("LEVEL1-despike", "Image has bad packets; no despiking applied")
-            logger.info(f"Bad packets---despiking skipped")
+            logger.info("Bad packets---despiking skipped")
         else:
             data = despike_polseq_task(data,
                                        despike_neighbors,
@@ -132,9 +132,9 @@ def level1_early_core_flow(  # noqa: C901
         data.data[:, :] = np.clip(dn_to_msb(data.data[:, :], data.wcs, **scaling), a_min=0, a_max=None)
         data.uncertainty.array[:, :] = dn_to_msb(data.uncertainty.array[:, :], data.wcs, **scaling)
 
-        if l0_data.meta['BADPKTS'].value:
+        if l0_data.meta["BADPKTS"].value:
             data.meta.history.add_now("LEVEL1-destreak", "Image has bad packets; no destreaking applied")
-            logger.info(f"Bad packets---destreaking skipped")
+            logger.info("Bad packets---destreaking skipped")
         else:
             data = destreak_task(data,
                                  exposure_time=exposure_time,


### PR DESCRIPTION
Bad packet images have a *lot* of pixels that look saturated. For these images, we shouldn't despike, destreak, or fill saturated pixels. (If nothing else, it just takes a long time to run with that many "saturated" pixels.)