### PR TITLE
Cleaner updates

### DIFF
--- a/changelog/783.feature.rst
+++ b/changelog/783.feature.rst
@@ -1,0 +1,1 @@
+Cleaner flow now understands the QL root, revivable flows even if file relationships are missing from DB. Also routinely deletes old Prefect flows to keep it from ballooning.

--- a/punchbowl/auto/control/cleaner.py
+++ b/punchbowl/auto/control/cleaner.py
@@ -70,13 +70,13 @@ def reset_revivable_flows(logger, session, pipeline_config):
     root_path = Path(pipeline_config["root"])
     for child in unique_children:
         output_path = Path(child.directory(pipeline_config["root"])) / child.filename()
-        lq_path = Path(child.directory(pipeline_config["ql_root"])) / child.filename()
+        ql_path = Path(child.directory(pipeline_config["ql_root"])) / child.filename()
         if output_path.exists():
             os.remove(output_path)
         sha_path = str(output_path) + ".sha"
         if os.path.exists(sha_path):
             os.remove(sha_path)
-        jp2_path = lq_path.with_suffix(".jp2")
+        jp2_path = ql_path.with_suffix(".jp2")
         if jp2_path.exists():
             os.remove(jp2_path)
         # Iteratively remove parent directories if they're empty. output_path.parents gives the file's parent dir,

--- a/punchbowl/auto/control/cleaner.py
+++ b/punchbowl/auto/control/cleaner.py
@@ -70,12 +70,13 @@ def reset_revivable_flows(logger, session, pipeline_config):
     root_path = Path(pipeline_config["root"])
     for child in unique_children:
         output_path = Path(child.directory(pipeline_config["root"])) / child.filename()
+        lq_path = Path(child.directory(pipeline_config["ql_root"])) / child.filename()
         if output_path.exists():
             os.remove(output_path)
         sha_path = str(output_path) + ".sha"
         if os.path.exists(sha_path):
             os.remove(sha_path)
-        jp2_path = output_path.with_suffix(".jp2")
+        jp2_path = lq_path.with_suffix(".jp2")
         if jp2_path.exists():
             os.remove(jp2_path)
         # Iteratively remove parent directories if they're empty. output_path.parents gives the file's parent dir,

--- a/punchbowl/auto/control/tests/punchpipe_config.yaml
+++ b/punchbowl/auto/control/tests/punchpipe_config.yaml
@@ -1,4 +1,5 @@
 root: "./test_results/"
+ql_root:  "./test_results/L/"
 tlm_directory: "./test_results/"
 file_version: "1"
 

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -192,6 +192,7 @@ def write_ndcube_to_quicklook(cube: NDCube,
     arr_image = np.array(pil_image)
 
     tmp_filename = f"{filename}tmp.jp2"
+    os.makedirs(os.path.dirname(tmp_filename), exist_ok=True)
     jp2 = Jp2k(tmp_filename, arr_image)
     meta_boxes = jp2.box
     target_index = len(meta_boxes) - 1


### PR DESCRIPTION
The cleaner flow now:

* Understands the new QL root.

* Can still clean `revivable` flows if the FileRelationships are missing from the DB.

* Routinely deletes old flows from the Prefect database, to keep it from swelling. (Failed flows are never deleted so the log entries stick around.)