### PR TITLE
Changes in support of Chris's merging code

### DIFF
--- a/changelog/785.bugfix.rst
+++ b/changelog/785.bugfix.rst
@@ -1,0 +1,1 @@
+Propagate the OUTLIER flag as a bitmask properly.

--- a/punchbowl/auto/control/db.py
+++ b/punchbowl/auto/control/db.py
@@ -1,6 +1,6 @@
 import os
 
-from sqlalchemy import TEXT, Boolean, Column, Float, Index, Integer, String
+from sqlalchemy import TEXT, Boolean, Column, Float, Index, Integer, SmallInteger, String
 from sqlalchemy.dialects.mysql import DATETIME, MEDIUMTEXT
 from sqlalchemy.orm import declarative_base
 
@@ -21,7 +21,7 @@ class File(Base):
     date_end = Column(DATETIME(fsp=6), nullable=True)
     polarization = Column(String(2), nullable=True)
     state = Column(String(64), nullable=False)
-    outlier = Column(Boolean, nullable=False, default=False)
+    outlier = Column(SmallInteger, nullable=False, default=False)
     bad_packets = Column(Boolean, nullable=False, default=False)
     processing_flow = Column(Integer, nullable=True)
     crota = Column(Float, nullable=True)

--- a/punchbowl/auto/control/processor.py
+++ b/punchbowl/auto/control/processor.py
@@ -102,7 +102,12 @@ def generic_process_flow_logic(flow_id: int | list[int], core_flow_to_launch, pi
                 # Converts to local time
                 date_created = date_created.replace(tzinfo=UTC).astimezone()
                 file_db_entry.date_created = date_created
-                result.meta["OUTLIER"] = int(file_db_entry.outlier)
+                if result.meta['OUTLIER'].value == 0:
+                    # Stamp the DB value into this file, which hasn't had OUTLIER set yet
+                    result.meta["OUTLIER"] = file_db_entry.outlier
+                else:
+                    # The flow specifically set a value, so copy it back into the DB
+                    file_db_entry.outlier = result.meta["OUTLIER"].value
                 result.meta["BADPKTS"] = int(file_db_entry.bad_packets)
                 result.meta['BOWLVRSN'] = __version__
                 if 'SPPYVRSN' in result.meta:

--- a/punchbowl/auto/flows/fcorona.py
+++ b/punchbowl/auto/flows/fcorona.py
@@ -29,7 +29,7 @@ def f_corona_background_query_ready_files(session, pipeline_config: dict, refere
     base_query = (session.query(File)
                   .filter(File.state.in_(["created", "progressed"]))
                   .filter(File.observatory == reference_file.observatory)
-                  .filter(~File.outlier)
+                  .filter(File.outlier == 0)
                   )
 
     first_half_inputs = (base_query

--- a/punchbowl/auto/flows/level3.py
+++ b/punchbowl/auto/flows/level3.py
@@ -84,7 +84,7 @@ def level3_PTM_construct_flow_info(level2_files: list[File], level3_file: File,
 
 
 def level3_PTM_construct_file_info(input_files: list[File], pipeline_config: dict, reference_time=None) -> list[File]:
-    date_obses = [f.date_obs for f in input_files]
+    input_file = input_files[0]
 
     return [File(
                 level="3",
@@ -92,12 +92,12 @@ def level3_PTM_construct_file_info(input_files: list[File], pipeline_config: dic
                 observatory="M",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=input_files[0].date_obs,
+                date_obs=input_file.date_obs,
                 state="planned",
-                date_beg=min(date_obses),
-                date_end=max(date_obses),
-                outlier=any(file.outlier for file in input_files),
-                bad_packets=any(file.bad_packets for file in input_files),
+                date_beg=input_file.date_beg,
+                date_end=input_file.date_end,
+                outlier=input_file.outlier,
+                bad_packets=input_file.bad_packets,
             )]
 
 
@@ -187,7 +187,7 @@ def level3_PIM_construct_flow_info(level2_files: list[File], level3_file: File, 
 
 
 def level3_PIM_construct_file_info(level2_files: list[File], pipeline_config: dict, reference_time=None) -> list[File]:
-    date_obses = [f.date_obs for f in level2_files]
+    input_file = level2_files[0]
 
     return [File(
                 level="3",
@@ -195,12 +195,12 @@ def level3_PIM_construct_file_info(level2_files: list[File], pipeline_config: di
                 observatory="M",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=level2_files[0].date_obs,
+                date_obs=input_file.date_obs,
                 state="planned",
-                date_beg=min(date_obses),
-                date_end=max(date_obses),
-                outlier=any(file.outlier for file in level2_files),
-                bad_packets=any(file.bad_packets for file in level2_files),
+                date_beg=input_file.date_beg,
+                date_end=input_file.date_end,
+                outlier=input_file.outlier,
+                bad_packets=input_file.bad_packets,
             )]
 
 
@@ -295,7 +295,7 @@ def level3_CIM_construct_flow_info(level2_files: list[File], level3_file: File, 
 
 
 def level3_CIM_construct_file_info(level2_files: list[File], pipeline_config: dict, reference_time=None) -> list[File]:
-    date_obses = [f.date_obs for f in level2_files]
+    input_file = level2_files[0]
 
     return [File(
                 level="3",
@@ -303,12 +303,12 @@ def level3_CIM_construct_file_info(level2_files: list[File], pipeline_config: di
                 observatory="M",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=level2_files[0].date_obs,
+                date_obs=input_file.date_obs,
                 state="planned",
-                date_beg=min(date_obses),
-                date_end=max(date_obses),
-                outlier=any(file.outlier for file in level2_files),
-                bad_packets=any(file.bad_packets for file in level2_files),
+                date_beg=input_file.date_beg,
+                date_end=input_file.date_end,
+                outlier=input_file.outlier,
+                bad_packets=input_file.bad_packets,
             )]
 
 
@@ -392,7 +392,7 @@ def level3_CTM_construct_flow_info(level2_files: list[File], level3_file: File,
 
 
 def level3_CTM_construct_file_info(input_files: list[File], pipeline_config: dict, reference_time=None ) -> list[File]:
-    date_obses = [f.date_obs for f in input_files]
+    input_file = input_files[0]
 
     return [File(
                 level="3",
@@ -400,12 +400,12 @@ def level3_CTM_construct_file_info(input_files: list[File], pipeline_config: dic
                 observatory="M",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=input_files[0].date_obs,
+                date_obs=input_file.date_obs,
                 state="planned",
-                date_beg=min(date_obses),
-                date_end=max(date_obses),
-                outlier=any(file.outlier for file in input_files),
-                bad_packets=any(file.bad_packets for file in input_files),
+                date_beg=input_file.date_beg,
+                date_end=input_file.date_end,
+                outlier=input_file.outlier,
+                bad_packets=input_file.bad_packets,
             )]
 
 
@@ -535,8 +535,9 @@ def level3_CAMPAM_construct_file_info(level3_files: list[File], pipeline_config:
                 software_version=__version__,
                 date_obs=average_datetime([f.date_obs for f in level3_files]),
                 state="planned",
-                outlier=any(file.outlier for file in level3_files),
-                bad_packets=any(file.bad_packets for file in level3_files),
+                # Outlier images are excluded from CAMs and PAMs
+                outlier=0,
+                bad_packets=False,
             )]
 
 

--- a/punchbowl/auto/flows/levelq.py
+++ b/punchbowl/auto/flows/levelq.py
@@ -358,6 +358,7 @@ def levelq_CTM_construct_flow_info(CQM_files: list[File], output_file: File, pip
 
 
 def levelq_CTM_construct_file_info(level1_files: list[File], pipeline_config: dict, reference_time=None) -> list[File]:
+    input_file = level1_files[0]
     return [File(
                 level="Q",
                 file_type="CT",
@@ -365,10 +366,10 @@ def levelq_CTM_construct_file_info(level1_files: list[File], pipeline_config: di
                 polarization="C",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=average_datetime([f.date_obs for f in level1_files]),
+                date_obs=input_file.date_obs,
                 state="planned",
-                outlier=any(file.outlier for file in level1_files),
-                bad_packets=any(file.bad_packets for file in level1_files),
+                outlier=input_file.outlier,
+                bad_packets=input_file.bad_packets,
             ),
     ]
 

--- a/punchbowl/levelq/pca.py
+++ b/punchbowl/levelq/pca.py
@@ -93,7 +93,7 @@ def load_files(input_cubes: list[NDCube], files_to_fit: list[NDCube | str | Data
             body_finding_input = (meta, wcs)
         else:
             raise TypeError(f"Invalid type {type(input_file)} for input file")
-        is_good = not meta["OUTLIER"].value
+        is_good = meta["OUTLIER"].value == 0
         if is_good or input_list_index >= 0:
             loaded_input_list_indices.append(input_list_index)
             all_files_to_fit[index_to_insert] = data

--- a/scripts/auto/add_real_calibration_to_db.py
+++ b/scripts/auto/add_real_calibration_to_db.py
@@ -36,7 +36,7 @@ for model_path in model_paths:
         software_version=version,
         date_obs=date,
         polarization=code[1] if code[0] == 'P' else 'C',
-        outlier=False,
+        outlier=0,
         state='created',
     )
     session.add(file)

--- a/scripts/auto/import_export.py
+++ b/scripts/auto/import_export.py
@@ -56,7 +56,7 @@ class ExportedFile:
     polarization: str
     state: str
     crota: float
-    outlier: bool
+    outlier: int
     bad_packets: bool
     processing_flow: ExportedFlow
     parents: list[tuple]

--- a/scripts/auto/sync_db_to_files.py
+++ b/scripts/auto/sync_db_to_files.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
             date_obs=date,
             polarization=pol,
             state='created',
-            outlier=False,
+            outlier=0,
         )
 
         if file.filename() not in existing_files:


### PR DESCRIPTION
For L2 and L3 we now let OUTLIER be a bitmask indicating which instruments are bad. This updates the automation side to accommodate that and propagate values accordingly.

Critically, in the spot in `processor` where we stamp the DB `outlier` value into the file (and that DB value is copied from the input files' DB `outlier` values, so the flag propagates across data levels), the stamping works as normal if the file has its `OUTLIER` value set to the default 0. But if the file has its OUTLIER set, it is assumed that's a new, more correct value set on purpose by the core flow, so the value from the NDCube is copied into the DB. 

I also thought a bit about how other values in the DB are propagated across data levels. Often there's just one input file, so we don't have to be so clever about handling a list of input files (and this is good now that OUTLIER is supposed to be a number, not just a bool, so it's hard to combine across multiple input files).