### PR TITLE
Alters f-corona application masking

### DIFF
--- a/changelog/797.bugfix.rst
+++ b/changelog/797.bugfix.rst
@@ -1,0 +1,1 @@
+Alters f-corona subtraction to apply to in-painted data regions.

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -435,7 +435,7 @@ def subtract_f_corona_background(data_object: NDCube,
             allow_extrapolation=allow_extrapolation,
             and_uncertainty=True)
 
-    interpolated_model[np.isinf(data_object.uncertainty.array)] = 0
+    interpolated_model[(data_object.data == 0) & np.isinf(data_object.uncertainty.array)] = 0
 
     original_mask = (data_object.data == 0) * np.isinf(data_object.uncertainty.array)
     data_object.data[...] -= interpolated_model


### PR DESCRIPTION
The f-corona subtraction was zeroing out the interpolated model where the input data uncertainty was infinite. This was ignoring f-corona subtraction for cosmic ray corrected regions -- where there was a data value, but flagged with infinite uncertainty. This only zeros out the f-corona model where both the input data is zero and the uncertainty is infinite.

These ignored regions appeared much brighter in the subtracted image, appearing as speckles. This also likely explains how the saturated streaks re-appeared.