### PR TITLE
Add custom Fido client

### DIFF
--- a/changelog/828.feature.rst
+++ b/changelog/828.feature.rst
@@ -1,0 +1,1 @@
+Adds a custom Fido client with PUNCH data support.

--- a/examples/animating_data.py
+++ b/examples/animating_data.py
@@ -11,10 +11,10 @@ How to animate PUNCH data using built-in plotting tools
 # Note that for animation, you'll need a local copy of ffmpeg, which can be installed through tools such as homebrew or conda. Depending on your environment you may also need to install a corresponding python package with a command such as ``pip install ffmpeg-python``.
 # Also note that punchbowl is in active development at the moment. To install the bleeding-edge version, use a command such as ``pip install git+https://github.com/punch-mission/punchbowl@main``.
 
-from datetime import datetime
+from sunpy.net import Fido
+from sunpy.net import attrs as a
 
-from sunpy.net import Fido, attrs
-
+import punchbowl  # Note that this import is needed to register PUNCH fido tools
 from punchbowl.data.visualize import animate_punch
 
 # %% [markdown]
@@ -22,18 +22,12 @@ from punchbowl.data.visualize import animate_punch
 # Two useful datasets to visualize are CAM and PAM - level 3 clear and polarized low-noise mosaics.
 
 # %%
-start_time, end_time = datetime(2025, 10, 14, 14, 30, 0), datetime(2025, 10, 14, 17, 0, 0)
-product_code = "L3_CAM"    # Or L3_PAM for polarized data
-data_type = "Unpolarized"  # Or "Polar_BpB" for polarized data
-version_code = "v0j"
-
-result = Fido.search(
-                attrs.Time(start_time, end_time),
-                attrs.Source("PUNCH-MOSAIC"),
-                attrs.Instrument(data_type)
-            )
-
-result = result[0][[i for i, r in enumerate(result[0]['fileid']) if product_code in r and version_code in r]]
+result = Fido.search(a.Time('2025/10/14 14:30:00', '2025/10/14 17:00:00'),
+                     a.punch.ProductCode.ca, # (ca for clear low-noise), or pa for polarized low-noise, etc.
+                     a.Instrument.m, # (m for mosaic), or a.Instrument.nfi_4, etc for earlier levels.
+                     a.Level.three,
+                     a.punch.DataVersion.newest, # or a.punch.DataVersion.zero_j, etc.
+                     a.punch.FileType.fits) # or a.punch.FileType.jp2
 
 result
 

--- a/examples/querying_data.py
+++ b/examples/querying_data.py
@@ -7,27 +7,33 @@ A notebook guide to querying and loading PUNCH data using SunPy.
 """
 
 # %%
-# This notebook provides a guide on how to use tools to query PUNCH data from the VSO / SDAC using Python tools, and how to load and display this data using SunPy.
+# This notebook provides a guide on how to query PUNCH data from the SDAC / VSO using Python tools, and how to load and display this data.
+# Note that PUNCH provides some bespoke tools to assist Fido in querying the complex range of data products and versions of PUNCH.
 
 
 # %%
 # Load libraries
 
-from sunpy.map import Map
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 
+import punchbowl  # Note that this import is needed to register PUNCH fido tools
+from punchbowl.data import punch_io, visualize
+
 # %%
-# Data querying
-# ------------
-#
-# With a range of dates and a PUNCH instrument in mind, we can begin querying data. Here we'll consider data from the first two minutes of the first of June, and focus on data from WFI-2 only.
-#
+# With a range of dates and a PUNCH data product in mind, we can begin querying data.
+# Here we'll search for level 3 clear low-noise mosaics from 1-2 November 2025.
+# We're looking for CAM data, so a product code of "CA" and a instrument code of "M".
 # We can construct a query using the Fido tool, specifying search attributes:
 
 # %%
-time_range = a.Time('2025/06/01 00:00:00', '2025/06/01 00:02:00')
-result = Fido.search(time_range, a.Instrument('WFI-2'))
+result = Fido.search(a.Time('2025/10/30 12:00:00', '2025/10/31 12:00:00'),
+                     a.punch.ProductCode.ca, # (ca for clear low-noise), or pa for polarized low-noise, etc.
+                     a.Instrument.m, # (m for mosaic), or a.Instrument.nfi_4, etc for earlier levels.
+                     a.Level.three,
+                     a.punch.DataVersion.newest, # or a.punch.DataVersion.zero_j, etc.
+                     a.punch.FileType.fits) # or a.punch.FileType.jp2
+
 result
 
 # %%
@@ -42,14 +48,19 @@ except IndexError:
     files = None
 # %%
 # This returns a list of paths to files that have been downloaded. Note that the Fido.fetch tool can specify a particular download directory for larger data searches.
-# With that file downloaded, we can load it into a SunPy map object, and display it.
+# With that file downloaded, we can plot the data:
 
 # %%
 if files:
-    map = Map(files[0])
-    map.peek()
+    fig, ax = visualize.plot_punch(files[0])
 
 # %%
-# And that's it! From here the data is encapsulated into a SunPy map object, which supports that framework for plotting, coordinate transformations, etc.
-#
-# Of course this is just one path, you could always load the data using Astropy fits tools, load it into an NDCube, or any other FITS-compliant tool.
+# And that's it! From here the data is loaded into the PUNCH plotting tool and displayed.
+# Of course this is just one path, you could always load the data using the punchbowl.data.punch_io.load_ndcube_from_fits() function or Astropy fits tools.
+# As an example you could load this file using:
+
+# %%
+if files:
+    datacube = punch_io.load_ndcube_from_fits(files[0])
+
+datacube

--- a/punchbowl/__init__.py
+++ b/punchbowl/__init__.py
@@ -6,3 +6,5 @@ try:
   __version__ = importlib.metadata.version("punchbowl")
 except PackageNotFoundError:
   __version__ = "0.0.0"
+
+import punchbowl.data.fido

--- a/punchbowl/__init__.py
+++ b/punchbowl/__init__.py
@@ -7,4 +7,4 @@ try:
 except PackageNotFoundError:
   __version__ = "0.0.0"
 
-import punchbowl.data.fido
+from punchbowl.data import fido as fido

--- a/punchbowl/data/__init__.py
+++ b/punchbowl/data/__init__.py
@@ -1,4 +1,4 @@
-from punchbowl.data.fido import *
+import punchbowl.data.fido
 from punchbowl.data.history import History
 from punchbowl.data.meta import NormalizedMetadata
 from punchbowl.data.punch_io import (

--- a/punchbowl/data/__init__.py
+++ b/punchbowl/data/__init__.py
@@ -1,3 +1,4 @@
+from punchbowl.data.fido import *
 from punchbowl.data.history import History
 from punchbowl.data.meta import NormalizedMetadata
 from punchbowl.data.punch_io import (

--- a/punchbowl/data/__init__.py
+++ b/punchbowl/data/__init__.py
@@ -1,4 +1,4 @@
-import punchbowl.data.fido
+from punchbowl.data import fido as fido
 from punchbowl.data.history import History
 from punchbowl.data.meta import NormalizedMetadata
 from punchbowl.data.punch_io import (

--- a/punchbowl/data/fido/__init__.py
+++ b/punchbowl/data/fido/__init__.py
@@ -1,0 +1,3 @@
+from .client import PUNCHClient
+
+__all__ = ["PUNCHClient"]

--- a/punchbowl/data/fido/attrs.py
+++ b/punchbowl/data/fido/attrs.py
@@ -5,10 +5,8 @@ class FileType(SimpleAttr):
     """File type attr."""
 
 
-
 class ProductCode(SimpleAttr):
     """PUNCH product code attr."""
-
 
 
 class DataVersion(SimpleAttr):

--- a/punchbowl/data/fido/attrs.py
+++ b/punchbowl/data/fido/attrs.py
@@ -2,12 +2,14 @@ from sunpy.net.attr import SimpleAttr
 
 
 class FileType(SimpleAttr):
-    pass
+    """File type attr."""
+
 
 
 class ProductCode(SimpleAttr):
-    pass
+    """PUNCH product code attr."""
+
 
 
 class DataVersion(SimpleAttr):
-    pass
+    """Data version attr."""

--- a/punchbowl/data/fido/attrs.py
+++ b/punchbowl/data/fido/attrs.py
@@ -1,0 +1,13 @@
+from sunpy.net.attr import SimpleAttr
+
+
+class Polarization(SimpleAttr):
+    pass
+
+
+class ProductCode(SimpleAttr):
+    pass
+
+
+class DataVersion(SimpleAttr):
+    pass

--- a/punchbowl/data/fido/attrs.py
+++ b/punchbowl/data/fido/attrs.py
@@ -1,7 +1,7 @@
 from sunpy.net.attr import SimpleAttr
 
 
-class Polarization(SimpleAttr):
+class FileType(SimpleAttr):
     pass
 
 

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -1,0 +1,66 @@
+POLS = ("R", "M", "Z", "P")
+PREFIXES = ["X", "Y", "S", "T"]
+CODES = ["CR", "PP", "PM", "PZ"] + [pre + c for c in POLS for pre in PREFIXES] + ["PT", "CT", "PI", "CI", "CF", "PF"]
+
+from itertools import product
+
+from sunpy.net.dataretriever.client import GenericClient, QueryResponse
+from sunpy.net.scraper import Scraper
+from sunpy.time import TimeRange
+
+
+class PUNCHClient(GenericClient):
+    pattern = "https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_v{DataVersion}.fits"
+
+    @classmethod
+    def _attrs_module(cls):
+        return "punch", "punchbowl.data.fido.attrs"
+
+    @classmethod
+    def register_values(cls):
+        from sunpy.net import attrs
+        adict = {
+            attrs.Instrument: [("WFI-1", "Wide Field Imager 1"),
+                               ("WFI-2", "Wide Field Imager 2"),
+                               ("WFI-3", "Wide Field Imager 3"),
+                               ("NFI", "Narrow Field Imager"),
+                               ("M", "PUNCH Mosaic") ],
+            attrs.punch.DataVersion: [(f"0{v}", "") for v in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]],
+            attrs.punch.ProductCode: [(code, "") for code in CODES],
+            attrs.Physobs: [("irradiance", "the flux of radiant energy per unit area.")],  # TODO: Is this right?
+            attrs.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere.")],
+            attrs.Provider: [("SwRI", "Southwest Research Institute.")],
+            attrs.Level: [("0", "L0"),
+                          ("1", "L1"),
+                          ("2", "L2"),
+                          ("3", "L3"),
+                          ("Q", "LQ")]}
+        return adict
+
+    instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi": 4, "m": "M"}
+
+    def search(self, *args, **kwargs):
+        matchdict = self._get_match_dict(*args, **kwargs)
+        req_codes = matchdict.get("ProductCode")
+        req_instrs = matchdict.get("Instrument")
+        req_levels = matchdict.get("Level")
+        req_versions = matchdict.get("DataVersion")
+
+        metalist = []
+        for code, instr, level, dversion in product(req_codes, req_instrs, req_levels, req_versions):
+            code = code.upper()
+            url_instr = self.instr_replacements[instr]
+            fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level, "DataVersion": dversion}
+
+            urlpattern = self.pattern.format(**fdict)
+            urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")
+            scraper = Scraper(format=urlpattern)
+            tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
+            filesmeta = scraper._extract_files_meta(tr)
+            for i in filesmeta:
+                rowdict = self.post_search_hook(i, matchdict)
+                rowdict["ProductCode"] = code
+                rowdict["Instrument"] = instr.upper()
+                rowdict["DataVersion"] = dversion.lower()
+                metalist.append(rowdict)
+        return QueryResponse(metalist, client=self)

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -128,5 +128,6 @@ class PUNCHClient(GenericClient):
                 rowdict["DataVersion"] = dversion.lower()
                 rowdict["Provider"] = "SwRI"
                 rowdict["Level"] = level.upper()
+                rowdict["FileType"] = file_type
                 metalist.append(rowdict)
         return QueryResponse(metalist, client=self)

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -129,7 +129,8 @@ class PUNCHClient(GenericClient):
             # and product code. Scraper will handle day/month/year, and "wildcards" in the filename part of the URL
             # will be matched and the values extracted.
             urlpattern = self.pattern.format(**fdict)
-
+            urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")
+            
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
             filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -1,3 +1,13 @@
+from itertools import product
+
+from sunpy.net import attrs as a
+from sunpy.net.attr import SimpleAttr
+from sunpy.net.dataretriever.client import GenericClient, QueryResponse
+from sunpy.net.scraper import Scraper
+from sunpy.time import TimeRange
+
+from .attrs import FileType
+
 POLS = ["R", "M", "Z", "P"]
 PREFIXES = ["X", "Y", "S", "T", "G"]
 L0_1_CODES = ["CR", "PP", "PM", "PZ", "DK", "DS", "DY", "FQ", "QR", "RC", "RM", "RZ", "RP"]
@@ -5,17 +15,11 @@ L2_3_CODES = ["PT", "CT", "PI", "CI", "PF", "CF", "PA", "CA", "CN", "CQ"]
 CODES = L0_1_CODES + [pre + c for c in POLS for pre in PREFIXES] + L2_3_CODES
 ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 
-from itertools import product
-
-from sunpy.net.dataretriever.client import GenericClient, QueryResponse
-from sunpy.net.scraper import Scraper
-from sunpy.time import TimeRange
-
 
 class PUNCHClient(GenericClient):
     pattern = ("https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/"
                "{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}"
-               "{{minute:2d}}{{second:2d}}_v{DataVersion}.fits")
+               "{{minute:2d}}{{second:2d}}_v{DataVersion}.{FileType}")
 
     @classmethod
     def _attrs_module(cls):
@@ -39,23 +43,78 @@ class PUNCHClient(GenericClient):
             attrs.punch.DataVersion: [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
             attrs.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],
             attrs.Provider: [("SwRI", "Southwest Research Institute")],
+            attrs.punch.FileType: [("fits", "FITS file"), ("jp2", "Quick-look JPEG2000")],
         }
         return adict
 
     instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi-4": 4, "m": "M"}
 
+    def _get_match_dict(cls, *args, **kwargs):
+        """
+        Constructs a dictionary using the query and registered Attrs that represents
+        all possible values of the extracted metadata for files that matches the query.
+        The returned dictionary is used to validate the metadata of searched files
+        in :func:`~sunpy.net.scraper.Scraper._extract_files_meta`.
+
+        Parameters
+        ----------
+        \\*args: `tuple`
+            `sunpy.net.attrs` objects representing the query.
+        \\*\\*kwargs: `dict`
+            Any extra keywords to refine the search.
+
+        Returns
+        -------
+        matchdict: `dict`
+            A dictionary having a `list` of all possible Attr values
+            corresponding to an Attr.
+
+        """
+        regattrs_dict = cls.register_values()
+        matchdict = {}
+        for i in regattrs_dict.keys():
+            attrname = i.__name__
+            # only Attr values that are subclas of Simple Attr are stored as list in matchdict
+            # since complex attrs like Range can't be compared with string matching.
+            if i is FileType:
+                matchdict[attrname] = ["fits"]
+            elif issubclass(i, SimpleAttr):
+                matchdict[attrname] = []
+                for val, _ in regattrs_dict[i]:
+                    matchdict[attrname].append(val)
+        for elem in args:
+            if isinstance(elem, a.Time):
+                matchdict["Start Time"] = elem.start
+                matchdict["End Time"] = elem.end
+            elif hasattr(elem, "value"):
+                matchdict[elem.__class__.__name__] = [str(elem.value).lower()]
+            elif isinstance(elem, a.Wavelength):
+                matchdict["Wavelength"] = elem
+            else:
+                raise ValueError(
+                    f"GenericClient can not add {elem.__class__.__name__} to the rowdict dictionary to pass to the Client.")
+        return matchdict
+
     def search(self, *args, **kwargs):
+        for arg in args:
+            print(arg)
+        for k, v in kwargs.items():
+            print(k, v)
         matchdict = self._get_match_dict(*args, **kwargs)
+        print(matchdict)
         req_codes = matchdict.get("ProductCode")
         req_instrs = matchdict.get("Instrument")
         req_levels = matchdict.get("Level")
         req_versions = matchdict.get("DataVersion")
+        req_file_types = matchdict.get("FileType")
 
         metalist = []
-        for code, instr, level, dversion in product(req_codes, req_instrs, req_levels, req_versions):
+        for code, instr, level, dversion, file_type in product(
+                req_codes, req_instrs, req_levels, req_versions, req_file_types):
             code = code.upper()
             url_instr = self.instr_replacements[instr]
-            fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level, "DataVersion": dversion}
+            fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level, "DataVersion": dversion,
+                     "FileType": file_type}
 
             urlpattern = self.pattern.format(**fdict)
             urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -6,7 +6,7 @@ from sunpy.net.dataretriever.client import GenericClient, QueryResponse
 from sunpy.net.scraper import Scraper
 from sunpy.time import TimeRange
 
-from .attrs import FileType
+from .attrs import DataVersion, FileType
 
 POLS = ["R", "M", "Z", "P"]
 PREFIXES = ["X", "Y", "S", "T", "G"]
@@ -21,7 +21,7 @@ class PUNCHClient(GenericClient):
 
     pattern = ("https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/"
                "{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}"
-               "{{minute:2d}}{{second:2d}}_v{DataVersion}.{FileType}")
+               "{{minute:2d}}{{second:2d}}_v{{DataVersion}}.{FileType}")
 
     @classmethod
     def _attrs_module(cls) -> tuple[str, str]:
@@ -42,7 +42,8 @@ class PUNCHClient(GenericClient):
                                ("NFI-4", "Narrow Field Imager"),
                                ("M", "PUNCH Mosaic") ],
             a.punch.ProductCode: [(code, code) for code in CODES],
-            a.punch.DataVersion: [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
+            a.punch.DataVersion: [("newest", "Newest available")]
+                                 + [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
             a.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],
             a.Provider: [("SwRI", "Southwest Research Institute")],
             a.punch.FileType: [("fits", "FITS file"), ("jp2", "Quick-look JPEG2000")],
@@ -80,6 +81,8 @@ class PUNCHClient(GenericClient):
             # since complex attrs like Range can't be compared with string matching.
             if i is FileType:
                 matchdict[attrname] = ["fits"]
+            elif i is DataVersion:
+                matchdict[attrname] = ["newest"]
             elif issubclass(i, SimpleAttr):
                 matchdict[attrname] = []
                 for val, _ in regattrs_dict[i]:
@@ -113,7 +116,7 @@ class PUNCHClient(GenericClient):
                 req_codes, req_instrs, req_levels, req_versions, req_file_types):
             code = code.upper() # noqa: PLW2901
             url_instr = instr_replacements[instr]
-            fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level, "DataVersion": dversion,
+            fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level,
                      "FileType": file_type}
 
             urlpattern = self.pattern.format(**fdict)
@@ -121,11 +124,26 @@ class PUNCHClient(GenericClient):
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
             filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001
-            for i in filesmeta:
-                rowdict = self.post_search_hook(i, matchdict)
+
+            if dversion == "newest":
+                newest_file_by_date = {}
+                for row in filesmeta:
+                    tstamp = (row["year"], row["month"], row["day"], row["hour"], row["minute"], row["second"])
+                    entry = (row["DataVersion"], row)
+                    if tstamp in newest_file_by_date:
+                        if row["DataVersion"] > newest_file_by_date[tstamp][0]:
+                            newest_file_by_date[tstamp] = entry
+                    else:
+                        newest_file_by_date[tstamp] = entry
+                filesmeta = []
+                for key in sorted(newest_file_by_date.keys()):
+                    filesmeta.append(newest_file_by_date[key][1])
+
+            for row in filesmeta:
+                rowdict = self.post_search_hook(row, matchdict)
                 rowdict["ProductCode"] = code
                 rowdict["Instrument"] = instr.upper()
-                rowdict["DataVersion"] = dversion.lower()
+                rowdict["DataVersion"] = row["DataVersion"].lower()
                 rowdict["Provider"] = "SwRI"
                 rowdict["Level"] = level.upper()
                 rowdict["FileType"] = file_type

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -1,6 +1,9 @@
-POLS = ("R", "M", "Z", "P")
-PREFIXES = ["X", "Y", "S", "T"]
-CODES = ["CR", "PP", "PM", "PZ"] + [pre + c for c in POLS for pre in PREFIXES] + ["PT", "CT", "PI", "CI", "CF", "PF"]
+POLS = ["R", "M", "Z", "P"]
+PREFIXES = ["X", "Y", "S", "T", "G"]
+L0_1_CODES = ["CR", "PP", "PM", "PZ", "DK", "DS", "DY", "FQ", "QR", "RC", "RM", "RZ", "RP"]
+L2_3_CODES = ["PT", "CT", "PI", "CI", "PF", "CF", "PA", "CA", "CN", "CQ"]
+CODES = L0_1_CODES + [pre + c for c in POLS for pre in PREFIXES] + L2_3_CODES
+ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 
 from itertools import product
 
@@ -10,7 +13,9 @@ from sunpy.time import TimeRange
 
 
 class PUNCHClient(GenericClient):
-    pattern = "https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_v{DataVersion}.fits"
+    pattern = ("https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/"
+               "{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}"
+               "{{minute:2d}}{{second:2d}}_v{DataVersion}.fits")
 
     @classmethod
     def _attrs_module(cls):
@@ -20,24 +25,24 @@ class PUNCHClient(GenericClient):
     def register_values(cls):
         from sunpy.net import attrs
         adict = {
-            attrs.Instrument: [("WFI-1", "Wide Field Imager 1"),
-                               ("WFI-2", "Wide Field Imager 2"),
-                               ("WFI-3", "Wide Field Imager 3"),
-                               ("NFI", "Narrow Field Imager"),
-                               ("M", "PUNCH Mosaic") ],
-            attrs.punch.DataVersion: [(f"0{v}", "") for v in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]],
-            attrs.punch.ProductCode: [(code, "") for code in CODES],
-            attrs.Physobs: [("irradiance", "the flux of radiant energy per unit area.")],  # TODO: Is this right?
-            attrs.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere.")],
-            attrs.Provider: [("SwRI", "Southwest Research Institute.")],
             attrs.Level: [("0", "L0"),
                           ("1", "L1"),
                           ("2", "L2"),
                           ("3", "L3"),
-                          ("Q", "LQ")]}
+                          ("Q", "LQ")],
+            attrs.Instrument: [("WFI-1", "Wide Field Imager 1"),
+                               ("WFI-2", "Wide Field Imager 2"),
+                               ("WFI-3", "Wide Field Imager 3"),
+                               ("NFI-4", "Narrow Field Imager"),
+                               ("M", "PUNCH Mosaic") ],
+            attrs.punch.ProductCode: [(code, code) for code in CODES],
+            attrs.punch.DataVersion: [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
+            attrs.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],
+            attrs.Provider: [("SwRI", "Southwest Research Institute")],
+        }
         return adict
 
-    instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi": 4, "m": "M"}
+    instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi-4": 4, "m": "M"}
 
     def search(self, *args, **kwargs):
         matchdict = self._get_match_dict(*args, **kwargs)
@@ -62,5 +67,7 @@ class PUNCHClient(GenericClient):
                 rowdict["ProductCode"] = code
                 rowdict["Instrument"] = instr.upper()
                 rowdict["DataVersion"] = dversion.lower()
+                rowdict["Provider"] = "SwRI"
+                rowdict["Level"] = level.upper()
                 metalist.append(rowdict)
         return QueryResponse(metalist, client=self)

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -17,40 +17,42 @@ ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 
 
 class PUNCHClient(GenericClient):
+    """Fido client for fetching PUNCH data from the SDAC."""
+
     pattern = ("https://umbra.nascom.nasa.gov/punch/{Level}/{ProductCode}{Instrument}/{{year:4d}}/{{month:2d}}/"
                "{{day:2d}}/PUNCH_L{Level}_{ProductCode}{Instrument}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}"
                "{{minute:2d}}{{second:2d}}_v{DataVersion}.{FileType}")
 
     @classmethod
-    def _attrs_module(cls):
+    def _attrs_module(cls) -> tuple[str, str]:
         return "punch", "punchbowl.data.fido.attrs"
 
     @classmethod
-    def register_values(cls):
-        from sunpy.net import attrs
-        adict = {
-            attrs.Level: [("0", "L0"),
+    def register_values(cls) -> dict:
+        """Register supported attrs with Fido."""
+        return {
+            a.Level: [("0", "L0"),
                           ("1", "L1"),
                           ("2", "L2"),
                           ("3", "L3"),
                           ("Q", "LQ")],
-            attrs.Instrument: [("WFI-1", "Wide Field Imager 1"),
+            a.Instrument: [("WFI-1", "Wide Field Imager 1"),
                                ("WFI-2", "Wide Field Imager 2"),
                                ("WFI-3", "Wide Field Imager 3"),
                                ("NFI-4", "Narrow Field Imager"),
                                ("M", "PUNCH Mosaic") ],
-            attrs.punch.ProductCode: [(code, code) for code in CODES],
-            attrs.punch.DataVersion: [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
-            attrs.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],
-            attrs.Provider: [("SwRI", "Southwest Research Institute")],
-            attrs.punch.FileType: [("fits", "FITS file"), ("jp2", "Quick-look JPEG2000")],
+            a.punch.ProductCode: [(code, code) for code in CODES],
+            a.punch.DataVersion: [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
+            a.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],
+            a.Provider: [("SwRI", "Southwest Research Institute")],
+            a.punch.FileType: [("fits", "FITS file"), ("jp2", "Quick-look JPEG2000")],
         }
-        return adict
 
-    instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi-4": 4, "m": "M"}
-
-    def _get_match_dict(cls, *args, **kwargs):
+    @classmethod
+    def _get_match_dict(cls, *args: tuple, **kwargs: dict) -> dict: # noqa: ARG003
         """
+        Override of class method to support default value for FileType.
+
         Constructs a dictionary using the query and registered Attrs that represents
         all possible values of the extracted metadata for files that matches the query.
         The returned dictionary is used to validate the metadata of searched files
@@ -58,9 +60,9 @@ class PUNCHClient(GenericClient):
 
         Parameters
         ----------
-        \\*args: `tuple`
+        args: `tuple`
             `sunpy.net.attrs` objects representing the query.
-        \\*\\*kwargs: `dict`
+        kwargs: `dict`
             Any extra keywords to refine the search.
 
         Returns
@@ -72,7 +74,7 @@ class PUNCHClient(GenericClient):
         """
         regattrs_dict = cls.register_values()
         matchdict = {}
-        for i in regattrs_dict.keys():
+        for i in regattrs_dict:
             attrname = i.__name__
             # only Attr values that are subclas of Simple Attr are stored as list in matchdict
             # since complex attrs like Range can't be compared with string matching.
@@ -91,28 +93,26 @@ class PUNCHClient(GenericClient):
             elif isinstance(elem, a.Wavelength):
                 matchdict["Wavelength"] = elem
             else:
-                raise ValueError(
-                    f"GenericClient can not add {elem.__class__.__name__} to the rowdict dictionary to pass to the Client.")
+                raise ValueError(f"GenericClient can not add {elem.__class__.__name__} to the rowdict dictionary to "
+                                 f"pass to the Client.")
         return matchdict
 
-    def search(self, *args, **kwargs):
-        for arg in args:
-            print(arg)
-        for k, v in kwargs.items():
-            print(k, v)
+    def search(self, *args: tuple, **kwargs: dict) -> QueryResponse:
+        """Override of base class method to run the search, handling PUNCH attrs."""
         matchdict = self._get_match_dict(*args, **kwargs)
-        print(matchdict)
         req_codes = matchdict.get("ProductCode")
         req_instrs = matchdict.get("Instrument")
         req_levels = matchdict.get("Level")
         req_versions = matchdict.get("DataVersion")
         req_file_types = matchdict.get("FileType")
 
+        instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi-4": 4, "m": "M"}
+
         metalist = []
         for code, instr, level, dversion, file_type in product(
                 req_codes, req_instrs, req_levels, req_versions, req_file_types):
-            code = code.upper()
-            url_instr = self.instr_replacements[instr]
+            code = code.upper() # noqa: PLW2901
+            url_instr = instr_replacements[instr]
             fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level, "DataVersion": dversion,
                      "FileType": file_type}
 
@@ -120,7 +120,7 @@ class PUNCHClient(GenericClient):
             urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
-            filesmeta = scraper._extract_files_meta(tr)
+            filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001
             for i in filesmeta:
                 rowdict = self.post_search_hook(i, matchdict)
                 rowdict["ProductCode"] = code

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -37,12 +37,12 @@ class PUNCHClient(GenericClient):
                           ("2", "L2"),
                           ("3", "L3"),
                           ("Q", "LQ")],
+            a.punch.ProductCode: [(code, code) for code in CODES],
             a.Instrument: [("WFI-1", "Wide Field Imager 1"),
                                ("WFI-2", "Wide Field Imager 2"),
                                ("WFI-3", "Wide Field Imager 3"),
                                ("NFI-4", "Narrow Field Imager"),
                                ("M", "PUNCH Mosaic") ],
-            a.punch.ProductCode: [(code, code) for code in CODES],
             a.punch.DataVersion: [("newest", "Newest available")]
                                  + [(f"{v}{subv}", f"{v}{subv}") for subv in ALPHABET for v in range(2)],
             a.Source: [("PUNCH", "Polarimeter to UNify the Corona and Heliosphere")],

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -130,7 +130,7 @@ class PUNCHClient(GenericClient):
             # will be matched and the values extracted.
             urlpattern = self.pattern.format(**fdict)
             urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")
-            
+
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
             filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -25,6 +25,7 @@ class PUNCHClient(GenericClient):
 
     @classmethod
     def _attrs_module(cls) -> tuple[str, str]:
+        """Tell Fido where our custom attributes are."""
         return "punch", "punchbowl.data.fido.attrs"
 
     @classmethod
@@ -52,7 +53,7 @@ class PUNCHClient(GenericClient):
     @classmethod
     def _get_match_dict(cls, *args: tuple, **kwargs: dict) -> dict: # noqa: ARG003
         """
-        Override of class method to support default value for FileType.
+        Override of class method to support default value for FileType and DataVersion.
 
         Constructs a dictionary using the query and registered Attrs that represents
         all possible values of the extracted metadata for files that matches the query.
@@ -79,6 +80,8 @@ class PUNCHClient(GenericClient):
             attrname = i.__name__
             # only Attr values that are subclas of Simple Attr are stored as list in matchdict
             # since complex attrs like Range can't be compared with string matching.
+            
+            # HERE is where we deviate from the base class method, setting single default values for these two fields.
             if i is FileType:
                 matchdict[attrname] = ["fits"]
             elif i is DataVersion:
@@ -102,6 +105,8 @@ class PUNCHClient(GenericClient):
 
     def search(self, *args: tuple, **kwargs: dict) -> QueryResponse:
         """Override of base class method to run the search, handling PUNCH attrs."""
+        # matchdict will contain all the attributes we support querying. For each attribute, we'll have the
+        # user-selected value if set, or the default if not. For some keys, the 'default' is all possible values.
         matchdict = self._get_match_dict(*args, **kwargs)
         req_codes = matchdict.get("ProductCode")
         req_instrs = matchdict.get("Instrument")
@@ -112,6 +117,7 @@ class PUNCHClient(GenericClient):
         instr_replacements = {"wfi-1": 1, "wfi-2": 2, "wfi-3": 3, "nfi-4": 4, "m": "M"}
 
         metalist = []
+        # For every possible combination of requested values, we have to build and scrape a URL.
         for code, instr, level, dversion, file_type in product(
                 req_codes, req_instrs, req_levels, req_versions, req_file_types):
             code = code.upper() # noqa: PLW2901
@@ -119,15 +125,21 @@ class PUNCHClient(GenericClient):
             fdict = {"ProductCode": code, "Instrument": url_instr, "Level": level,
                      "FileType": file_type}
 
+            # Scraper can only handle dates as "variables" in the url's directory path, so we have to fill in level
+            # and product code. Scraper will handle day/month/year, and "wildcards" in the filename part of the URL
+            # will be matched and the values extracted.
             urlpattern = self.pattern.format(**fdict)
-            urlpattern = urlpattern.replace("{", "{{").replace("}", "}}")
+            
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
             filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001
+            # filesmeta will contain each file matching the pattern, as well as the matched values for all the "{{
+            # Value}}" fields in the url pattern.
 
             if dversion == "newest":
                 newest_file_by_date = {}
                 for row in filesmeta:
+                    # For each timestamp, we'll track the highest data version we see
                     tstamp = (row["year"], row["month"], row["day"], row["hour"], row["minute"], row["second"])
                     entry = (row["DataVersion"], row)
                     if tstamp in newest_file_by_date:
@@ -135,12 +147,15 @@ class PUNCHClient(GenericClient):
                             newest_file_by_date[tstamp] = entry
                     else:
                         newest_file_by_date[tstamp] = entry
+                # Now we'll extract the newest versions
                 filesmeta = []
                 for key in sorted(newest_file_by_date.keys()):
                     filesmeta.append(newest_file_by_date[key][1])
 
             for row in filesmeta:
                 rowdict = self.post_search_hook(row, matchdict)
+                # For the fields that we pasted into the URL pattern, we now have to put the corresponding values in
+                # the table of files. We can also massage the values a bit.
                 rowdict["ProductCode"] = code
                 rowdict["Instrument"] = instr.upper()
                 rowdict["DataVersion"] = row["DataVersion"].lower()

--- a/punchbowl/data/fido/client.py
+++ b/punchbowl/data/fido/client.py
@@ -80,7 +80,7 @@ class PUNCHClient(GenericClient):
             attrname = i.__name__
             # only Attr values that are subclas of Simple Attr are stored as list in matchdict
             # since complex attrs like Range can't be compared with string matching.
-            
+
             # HERE is where we deviate from the base class method, setting single default values for these two fields.
             if i is FileType:
                 matchdict[attrname] = ["fits"]
@@ -129,7 +129,7 @@ class PUNCHClient(GenericClient):
             # and product code. Scraper will handle day/month/year, and "wildcards" in the filename part of the URL
             # will be matched and the values extracted.
             urlpattern = self.pattern.format(**fdict)
-            
+
             scraper = Scraper(format=urlpattern)
             tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
             filesmeta = scraper._extract_files_meta(tr) # noqa: SLF001


### PR DESCRIPTION
OK, this has had some testing now!

Supports:
* Every (I think) FITS product code we produce
* jp2 queries! `a.punch.FileType.fits` or `a.punch.FileType.jp2`, with fits as the default
* `a.punch.DataVersion.newest`, giving the latest version on a per-timestamp basis. `newest` is the default.


```python
import punchbowl
from sunpy.net import Fido, attrs as a
result = Fido.search(a.Time('2025/11/01', '2025/11/02'),
                     a.Instrument.m, # or a.Instrument.nfi_4, etc.
                     a.Level.two,
                     a.punch.DataVersion.newest, # or a.punch.DataVersion.zero_j, etc.
                     a.punch.FileType.fits, # or a.punch.FileType.jp2
                     a.punch.ProductCode.ct)

```

I think the rest of us should test it a bit, and then we can make an example notebook!

It's worth noting that this scrapes SDAC pages, so it has to load a page for every day in the time range, and for every product code, level, and observatory. For the non-date ones, if you don't make a choice, it tries every one. That's fine for level, but if it's searching every product code we make, that's a *lot* of urls! Every page gives all the data versions for that date, so we don't pay that cost for `newest` queries.