### PR TITLE
File levels in dashboard

### DIFF
--- a/changelog/832.feature.rst
+++ b/changelog/832.feature.rst
@@ -1,0 +1,1 @@
+In the files dashboard, file level is now a default group-by column, and is labeled more clearly in the graph.

--- a/punchbowl/auto/control/db.py
+++ b/punchbowl/auto/control/db.py
@@ -73,7 +73,7 @@ Index("get_cal_file", File.file_type, File.observatory, File.date_obs, File.stat
 Index("CNN", File.file_type, File.observatory, File.level, File.state, File.outlier)
 Index("processing_flow_index", File.processing_flow)
 # This is really useful for a files dashboard "show me what we made today" query
-Index("date_created_index", File.date_created, File.file_type)
+Index("date_created_index", File.date_created, File.file_type, File.level)
 Index("level0_uniqueness",
       File.level, File.polarization, File.file_type,
       File.observatory, File.file_version, File.date_obs,

--- a/punchbowl/auto/monitor/pages/files.py
+++ b/punchbowl/auto/monitor/pages/files.py
@@ -545,6 +545,11 @@ def make_y_axis_labels(dff):
     # Generate the label strings for the plot y axis
     joinables = []
     columns = list(dff.columns)
+
+    if "level" in columns:
+        joinables.append(dff["level"].radd("L"))
+        columns.remove("level")
+
     if "file_type" in columns and "observatory" in columns:
         # If we're grouping by these columns, special-case it to show e.g. "CR2" instead of "CR 2" or "2 CR" or whatever
         joinables.append(dff["file_type"] + dff["observatory"])

--- a/punchbowl/auto/monitor/pages/files.py
+++ b/punchbowl/auto/monitor/pages/files.py
@@ -68,7 +68,7 @@ def layout():
                         "Show in Table: ",
                         dcc.Checklist(
                             USABLE_COLUMNS,
-                            ["File type", "Observatory"],
+                            ["Level", "File type", "Observatory"],
                             inline=True,
                             id="show-in-table",
                             inputStyle={"margin-left": "10px", "margin-right": "3px"},
@@ -79,7 +79,7 @@ def layout():
                         "Group by: ",
                         dcc.Checklist(
                             USABLE_COLUMNS,
-                            ["File type", "Observatory"],
+                            ["Level", "File type", "Observatory"],
                             inline=True,
                             id="group-by",
                             inputStyle={"margin-left": "10px", "margin-right": "3px"},
@@ -153,7 +153,9 @@ def layout():
 
                              sort_action="custom",
                              sort_mode="multi",
-                             sort_by=[dict(column_id="file_type", direction="asc"), dict(column_id="observatory", direction="asc")],
+                             sort_by=[dict(column_id="level", direction="asc"),
+                                      dict(column_id="file_type", direction="asc"),
+                                      dict(column_id="observatory", direction="asc")],
                              style_table={"overflowX": "auto",
                                           "textAlign": "left"},
                              fill_width=False,


### PR DESCRIPTION
Adds file level as a default group-by column. For the "show me everything" presets, we want this so e.g. L0 and L1 CR files are separated.

On the graph, labels levels as e.g. "L2" instead of just "2".