### PR TITLE
Integrate chimera usage into punchbowl automation

### DIFF
--- a/changelog/839.feature.2.rst
+++ b/changelog/839.feature.2.rst
@@ -1,0 +1,1 @@
+Adds host tracking to the health stats of the computer.

--- a/changelog/839.feature.3.rst
+++ b/changelog/839.feature.3.rst
@@ -1,0 +1,1 @@
+Allow duplicating control flows by host, e.g. "launcher-chimera" runs on chimera while "launcher-phoenix" runs on phoenix.

--- a/changelog/839.feature.rst
+++ b/changelog/839.feature.rst
@@ -1,1 +1,1 @@
-Allows deploying only enabled flows.
+Allows deploying flows only on certain machines using "run-on" option.

--- a/changelog/839.feature.rst
+++ b/changelog/839.feature.rst
@@ -1,0 +1,1 @@
+Allows deploying only enabled flows.

--- a/punchbowl/auto/cli.py
+++ b/punchbowl/auto/cli.py
@@ -18,6 +18,9 @@ from punchbowl.auto.control.util import load_pipeline_configuration
 
 THIS_DIR = os.path.dirname(__file__)
 
+def shorten_host(hostname):
+    return hostname.split(".")[0]
+
 def main():
     """Run the PUNCH automated pipeline"""
     parser = argparse.ArgumentParser(prog="punchpipe")
@@ -30,19 +33,16 @@ def main():
     run_parser.add_argument("config", type=str, help="Path to config.")
     run_parser.add_argument("--launch-prefect", action="store_true", help="Launch the prefect server")
     run_parser.add_argument("--no-dask-cluster", action="store_true", help="Skip launching the dask cluster")
-    run_parser.add_argument("--only-enabled-flows", action="store_true",
-                            default=False,
-                            help="Only deploy enabled flows to Prefect")
     serve_control_parser.add_argument("config", type=str, help="Path to config.")
     serve_data_parser.add_argument("config", type=str, help="Path to config.")
     args = parser.parse_args()
 
     if args.command == "run":
-        run(args.config, args.launch_prefect, not args.no_dask_cluster, args.only_enabled_flows)
+        run(args.config, args.launch_prefect, not args.no_dask_cluster)
     elif args.command == "serve-data":
-        run_data(args.config, args.only_enabled_flows)
+        run_data(args.config)
     elif args.command == "serve-control":
-        run_control(args.config, args.only_enabled_flows)
+        run_control(args.config)
     else:
         parser.print_help()
 
@@ -56,7 +56,8 @@ def find_flow(target_flow, subpackage="flows") -> Flow:
                     return obj
     raise RuntimeError(f"No flow found for {target_flow}")
 
-def construct_flows_to_serve(configuration_path, include_data=True, include_control=True, only_enabled=False):
+def construct_flows_to_serve(configuration_path, include_data=True, include_control=True):
+    current_host = shorten_host(socket.gethostname())
     config = load_pipeline_configuration(configuration_path)
 
     # create each kind of flow. add both the scheduler and process flow variant of it.
@@ -67,11 +68,12 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
             specific_name = flow_name + "_scheduler_flow"
             specific_tags = config["flows"][flow_name].get("tags", [])
             specific_description = config["flows"][flow_name].get("description", "")
+            desired_host = shorten_host(config["flows"][flow_name].get("run-on", current_host))
             flow_function = find_flow(specific_name)
             flow_deployment = flow_function.to_deployment(
                 name=specific_name,
                 description="Scheduler: " + specific_description,
-                tags = ["scheduler"] + specific_tags,
+                tags = ["scheduler", desired_host] + specific_tags,
                 cron=config["flows"][flow_name].get("schedule", None),
                 concurrency_limit=ConcurrencyLimitConfig(
                     limit=1,
@@ -79,7 +81,7 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
                 ),
                 parameters={"pipeline_config_path": configuration_path},
             )
-            if (only_enabled and config['flows'][flow_name].get("enabled", True)) or not only_enabled:
+            if  desired_host == current_host:
                 flows_to_serve.append(flow_deployment)
 
             # then we deploy the corresponding process flow
@@ -93,54 +95,48 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
             flow_deployment = flow_function.to_deployment(
                 name=specific_name,
                 description="Process: " + specific_description,
-                tags = ["process"] + specific_tags,
+                tags = ["process", desired_host] + specific_tags,
                 parameters={"pipeline_config_path": configuration_path},
                 concurrency_limit=concurrency_config,
             )
-            if (only_enabled and config['flows'][flow_name].get("enabled", True)) or not only_enabled:
+            # only deploy if the host matches the desired host
+            if desired_host == current_host:
                 flows_to_serve.append(flow_deployment)
 
     if include_control:
         # there are special control flows that manage the pipeline instead of processing data
         # time to kick those off!
         for flow_name in config["control"]:
-            if "-" in flow_name:
-                generic_flow_name, host = flow_name.split("-")
-            else:
-                generic_flow_name = flow_name
-                host = socket.gethostname()
-
-            flow_function = find_flow(generic_flow_name, "control")
+            desired_host = shorten_host(config['control'][flow_name].get("run-on", current_host))
+            flow_function = find_flow(flow_name, "control")
             concurrency_config = ConcurrencyLimitConfig(
                     limit=1,
                     collision_strategy=ConcurrencyLimitStrategy.CANCEL_NEW,
                 )
             flow_deployment = flow_function.to_deployment(
-                name=flow_name,
+                name=flow_name+"-"+desired_host,
                 description=config["control"][flow_name].get("description", ""),
-                tags=["control", f"control-{host}"],
+                tags=["control", desired_host],
                 cron=config["control"][flow_name].get("schedule", "* * * * *"),
                 parameters={"pipeline_config_path": configuration_path},
                 concurrency_limit=concurrency_config,
             )
-            if (only_enabled and config['control'][flow_name].get("enabled", True)) or not only_enabled:
+            if desired_host == current_host:
                 flows_to_serve.append(flow_deployment)
     return flows_to_serve
 
-def run_data(configuration_path, only_enabled):
+def run_data(configuration_path):
     with get_client(sync_client=True) as client:
         client.create_concurrency_limit(tag="reproject", concurrency_limit=50)
         client.create_concurrency_limit(tag="image_loader", concurrency_limit=50)
     configuration_path = str(Path(configuration_path).resolve())
-    serve(*construct_flows_to_serve(configuration_path, include_control=False, include_data=True,
-                                    only_enabled=only_enabled))
+    serve(*construct_flows_to_serve(configuration_path, include_control=False, include_data=True))
 
-def run_control(configuration_path, only_enabled):
+def run_control(configuration_path):
     configuration_path = str(Path(configuration_path).resolve())
-    serve(*construct_flows_to_serve(configuration_path, include_control=True, include_data=False,
-                                    only_enabled=only_enabled))
+    serve(*construct_flows_to_serve(configuration_path, include_control=True, include_data=False))
 
-def run(configuration_path, launch_prefect=False, launch_dask_cluster=False, only_enabled=False):
+def run(configuration_path, launch_prefect=False, launch_dask_cluster=False):
     now = datetime.now()
 
     configuration_path = str(Path(configuration_path).resolve())
@@ -185,18 +181,10 @@ def run(configuration_path, launch_prefect=False, launch_dask_cluster=False, onl
             # These processes send a _lot_ of output, so we let it go to the screen instead of making the log file
             # enormous
             def data_process_launcher() -> subprocess.Popen:
-                if only_enabled:
-                    return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data",
-                                             "--only-enabled-flows", configuration_path])
-                else:
-                    return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data", configuration_path])
+                return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data", configuration_path])
 
             def control_process_launcher() -> subprocess.Popen:
-                if only_enabled:
-                    return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control",
-                                             "--only-enabled-flows", configuration_path])
-                else:
-                    return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control", configuration_path])
+                return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control", configuration_path])
 
             data_process = data_process_launcher()
             control_process = control_process_launcher()

--- a/punchbowl/auto/cli.py
+++ b/punchbowl/auto/cli.py
@@ -29,16 +29,19 @@ def main():
     run_parser.add_argument("config", type=str, help="Path to config.")
     run_parser.add_argument("--launch-prefect", action="store_true", help="Launch the prefect server")
     run_parser.add_argument("--no-dask-cluster", action="store_true", help="Skip launching the dask cluster")
+    run_parser.add_argument("--only-enabled-flows", action="store_true",
+                            default=False,
+                            help="Only deploy enabled flows to Prefect")
     serve_control_parser.add_argument("config", type=str, help="Path to config.")
     serve_data_parser.add_argument("config", type=str, help="Path to config.")
     args = parser.parse_args()
 
     if args.command == "run":
-        run(args.config, args.launch_prefect, not args.no_dask_cluster)
+        run(args.config, args.launch_prefect, not args.no_dask_cluster, args.only_enabled_flows)
     elif args.command == "serve-data":
-        run_data(args.config)
+        run_data(args.config, args.only_enabled_flows)
     elif args.command == "serve-control":
-        run_control(args.config)
+        run_control(args.config, args.only_enabled_flows)
     else:
         parser.print_help()
 
@@ -52,7 +55,7 @@ def find_flow(target_flow, subpackage="flows") -> Flow:
                     return obj
     raise RuntimeError(f"No flow found for {target_flow}")
 
-def construct_flows_to_serve(configuration_path, include_data=True, include_control=True):
+def construct_flows_to_serve(configuration_path, include_data=True, include_control=True, only_enabled=False):
     config = load_pipeline_configuration(configuration_path)
 
     # create each kind of flow. add both the scheduler and process flow variant of it.
@@ -75,7 +78,8 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
                 ),
                 parameters={"pipeline_config_path": configuration_path},
             )
-            flows_to_serve.append(flow_deployment)
+            if (only_enabled and config['flows'][flow_name].get("enabled", True)) or not only_enabled:
+                flows_to_serve.append(flow_deployment)
 
             # then we deploy the corresponding process flow
             specific_name = flow_name + "_process_flow"
@@ -92,7 +96,8 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
                 parameters={"pipeline_config_path": configuration_path},
                 concurrency_limit=concurrency_config,
             )
-            flows_to_serve.append(flow_deployment)
+            if (only_enabled and config['flows'][flow_name].get("enabled", True)) or not only_enabled:
+                flows_to_serve.append(flow_deployment)
 
     if include_control:
         # there are special control flows that manage the pipeline instead of processing data
@@ -111,21 +116,24 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
                 parameters={"pipeline_config_path": configuration_path},
                 concurrency_limit=concurrency_config,
             )
-            flows_to_serve.append(flow_deployment)
+            if (only_enabled and config['control'][flow_name].get("enabled", True)) or not only_enabled:
+                flows_to_serve.append(flow_deployment)
     return flows_to_serve
 
-def run_data(configuration_path):
+def run_data(configuration_path, only_enabled):
     with get_client(sync_client=True) as client:
         client.create_concurrency_limit(tag="reproject", concurrency_limit=50)
         client.create_concurrency_limit(tag="image_loader", concurrency_limit=50)
     configuration_path = str(Path(configuration_path).resolve())
-    serve(*construct_flows_to_serve(configuration_path, include_control=False, include_data=True))
+    serve(*construct_flows_to_serve(configuration_path, include_control=False, include_data=True,
+                                    only_enabled=only_enabled))
 
-def run_control(configuration_path):
+def run_control(configuration_path, only_enabled):
     configuration_path = str(Path(configuration_path).resolve())
-    serve(*construct_flows_to_serve(configuration_path, include_control=True, include_data=False))
+    serve(*construct_flows_to_serve(configuration_path, include_control=True, include_data=False,
+                                    only_enabled=only_enabled))
 
-def run(configuration_path, launch_prefect=False, launch_dask_cluster=False):
+def run(configuration_path, launch_prefect=False, launch_dask_cluster=False, only_enabled=False):
     now = datetime.now()
 
     configuration_path = str(Path(configuration_path).resolve())
@@ -170,10 +178,18 @@ def run(configuration_path, launch_prefect=False, launch_dask_cluster=False):
             # These processes send a _lot_ of output, so we let it go to the screen instead of making the log file
             # enormous
             def data_process_launcher() -> subprocess.Popen:
-                return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data", configuration_path])
+                if only_enabled:
+                    return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data",
+                                             "--only-enabled-flows", configuration_path])
+                else:
+                    return subprocess.Popen([*numa_prefix_workers, "punchpipe", "serve-data", configuration_path])
 
             def control_process_launcher() -> subprocess.Popen:
-                return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control", configuration_path])
+                if only_enabled:
+                    return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control",
+                                             "--only-enabled-flows", configuration_path])
+                else:
+                    return subprocess.Popen([*numa_prefix_control, "punchpipe", "serve-control", configuration_path])
 
             data_process = data_process_launcher()
             control_process = control_process_launcher()

--- a/punchbowl/auto/cli.py
+++ b/punchbowl/auto/cli.py
@@ -1,5 +1,6 @@
 import os
 import time
+import socket
 import inspect
 import argparse
 import traceback
@@ -103,7 +104,13 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
         # there are special control flows that manage the pipeline instead of processing data
         # time to kick those off!
         for flow_name in config["control"]:
-            flow_function = find_flow(flow_name, "control")
+            if "-" in flow_name:
+                generic_flow_name, host = flow_name.split("-")
+            else:
+                generic_flow_name = flow_name
+                host = socket.gethostname()
+
+            flow_function = find_flow(generic_flow_name, "control")
             concurrency_config = ConcurrencyLimitConfig(
                     limit=1,
                     collision_strategy=ConcurrencyLimitStrategy.CANCEL_NEW,
@@ -111,7 +118,7 @@ def construct_flows_to_serve(configuration_path, include_data=True, include_cont
             flow_deployment = flow_function.to_deployment(
                 name=flow_name,
                 description=config["control"][flow_name].get("description", ""),
-                tags=["control"],
+                tags=["control", f"control-{host}"],
                 cron=config["control"][flow_name].get("schedule", "* * * * *"),
                 parameters={"pipeline_config_path": configuration_path},
                 concurrency_limit=concurrency_config,

--- a/punchbowl/auto/control/db.py
+++ b/punchbowl/auto/control/db.py
@@ -130,7 +130,7 @@ class Health(Base):
     disk_usage = Column(Float, nullable=False)
     disk_percentage = Column(Float, nullable=False)
     num_pids = Column(Integer, nullable=False)
-
+    host = Column(String(64), nullable=False)
 
 class PacketHistory(Base):
     __tablename__ = "packet_history"

--- a/punchbowl/auto/control/health.py
+++ b/punchbowl/auto/control/health.py
@@ -1,3 +1,4 @@
+import socket
 from datetime import datetime
 
 import psutil
@@ -26,9 +27,7 @@ def health_monitor(pipeline_config_path: str = None):
                                   memory_percentage=memory_percentage,
                                   disk_usage=disk_usage,
                                   disk_percentage=disk_percentage,
-                                  num_pids=num_pids)
+                                  num_pids=num_pids,
+                                  host=socket.gethostname())
         session.add(new_health_entry)
         session.commit()
-
-
-# TODO add zombie monitor!

--- a/punchbowl/auto/control/launcher.py
+++ b/punchbowl/auto/control/launcher.py
@@ -1,3 +1,4 @@
+import socket
 import asyncio
 from math import ceil
 from random import shuffle
@@ -11,16 +12,18 @@ from prefect.variables import Variable
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.orm import Session
 
+from punchbowl.auto.cli import shorten_host
 from punchbowl.auto.control.db import File, Flow
 from punchbowl.auto.control.util import batched, get_database_session, load_pipeline_configuration
 
 
 @task(cache_policy=NO_CACHE)
-def gather_planned_flows(session, weight_to_launch, max_flows_to_launch, flow_weights, flow_enabled, flow_batch_sizes):
+def gather_planned_flows(session, weight_to_launch, max_flows_to_launch, flow_weights, flow_enabled, flow_batch_sizes, flow_hosts):
     # We'll have to grab a bunch of possible flows to launch from the DB, and then on our end apply the weights and the
     # maximum-weight limit. But we can use the smallest weight to set an upper bound on how many launchable flows to
     # retrieve.
-    enabled_flows = [flow for flow, enabled in flow_enabled.items() if enabled]
+    current_host = shorten_host(socket.gethostname())
+    enabled_flows = [flow for flow, enabled in flow_enabled.items() if enabled and flow_hosts[flow] == current_host]
     if enabled_flows:
         max_to_select = weight_to_launch / min([flow_weights[k] for k in enabled_flows])
     else:
@@ -72,7 +75,7 @@ def gather_planned_flows(session, weight_to_launch, max_flows_to_launch, flow_we
 
 
 @task(cache_policy=NO_CACHE)
-def count_flows(session, weights):
+def count_flows(session, weights, flow_hosts):
     n_planned, n_running = 0, 0
     weight_planned, weight_running = 0, 0
     rows = session.execute(
@@ -81,14 +84,17 @@ def count_flows(session, weights):
         .where(Flow.state.in_(("planned", "running", "launched")))
         .group_by(Flow.state, Flow.flow_type),
     ).all()
+
+    current_host = shorten_host(socket.gethostname())
     # We won't get results for states that aren't actually in the database, so we have to inspect the returned rows
     for state, flow_type, count in rows:
-        if state == "planned":
-            n_planned += count
-            weight_planned += count * weights[flow_type]
-        else:
-            n_running += count
-            weight_running += count * weights[flow_type]
+        if current_host == flow_hosts[flow_type]:
+            if state == "planned":
+                n_planned += count
+                weight_planned += count * weights[flow_type]
+            else:
+                n_running += count
+                weight_running += count * weights[flow_type]
     return n_running, n_planned, weight_planned, weight_running
 
 
@@ -245,11 +251,13 @@ def load_flow_data(pipeline_config):
     flow_weights = dict()
     flow_enabled = dict()
     flow_batch_size = dict()
+    flow_hosts = dict()
     for flow_type in pipeline_config["flows"]:
         flow_enabled[flow_type] = pipeline_config["flows"][flow_type].get("enabled", True) is True
         flow_weights[flow_type] = pipeline_config["flows"][flow_type].get("launch_weight", 1)
         flow_batch_size[flow_type] = pipeline_config["flows"][flow_type].get("batch_size", 1)
-    return flow_weights, flow_enabled, flow_batch_size
+        flow_hosts[flow_type] = pipeline_config["flows"][flow_type].get("run-on", shorten_host(socket.gethostname()))
+    return flow_weights, flow_enabled, flow_batch_size, flow_hosts
 
 
 @flow
@@ -265,13 +273,15 @@ async def launcher(pipeline_config_path=None):
     Nothing
 
     """
+    current_host = shorten_host(socket.gethostname())
     logger = get_run_logger()
 
     if pipeline_config_path is None:
         pipeline_config_path = await Variable.get("punchpipe_config", "punchpipe_config.yaml")
     pipeline_config = load_pipeline_configuration(pipeline_config_path)
-    flow_weights, flow_enabled, flow_batch_sizes = load_flow_data(pipeline_config)
-    logger.info(f"Enabled flows: {', '.join([flow for flow, enabled in flow_enabled.items() if enabled])}")
+    flow_weights, flow_enabled, flow_batch_sizes, flow_hosts = load_flow_data(pipeline_config)
+    logger.info(f"Enabled flows on {current_host}: {', '.join([flow for flow, enabled in flow_enabled.items()
+                                             if enabled and flow_hosts[flow] == current_host])}")
 
     logger.info("Establishing database connection")
     session = get_database_session()
@@ -279,8 +289,9 @@ async def launcher(pipeline_config_path=None):
     escalate_long_waiting_flows(session, pipeline_config)
 
     # Perform the launcher flow responsibilities
-    num_running_flows, num_planned_flows, weight_planned, weight_running = count_flows(session, flow_weights)
-    logger.info(f"There are {num_running_flows} flows running right now (weight {weight_running:.2f}) and {num_planned_flows} planned flows (weight {weight_planned:.2f}).")
+    num_running_flows, num_planned_flows, weight_planned, weight_running = count_flows(session, flow_weights, flow_hosts)
+    logger.info(f"There are {num_running_flows} flows running right now on {current_host} "
+                f"(weight {weight_running:.2f}) and {num_planned_flows} planned flows (weight {weight_planned:.2f}).")
     max_weight_running = pipeline_config["control"]["launcher"]["max_weight_running"]
     max_weight_to_launch = pipeline_config["control"]["launcher"]["max_weight_to_launch_at_once"]
     max_flows_to_launch = pipeline_config["control"]["launcher"]["max_flows_to_launch_at_once"]
@@ -289,7 +300,7 @@ async def launcher(pipeline_config_path=None):
         weight_planned, weight_running, max_weight_running, max_weight_to_launch, max_flows_to_launch)
 
     flows_to_launch, tags_by_flow, selected_weight, number_of_flows, counts_per_type = gather_planned_flows(
-        session, weight_to_launch, max_flows_to_launch, flow_weights, flow_enabled, flow_batch_sizes)
+        session, weight_to_launch, max_flows_to_launch, flow_weights, flow_enabled, flow_batch_sizes, flow_hosts)
     ids = [[flow.flow_id for flow in batch] for batch in flows_to_launch]
     logger.info(f"{number_of_flows} flows (weight {selected_weight:.2f}) with IDs of {ids} will be launched.")
     counts = [f"{counts_per_type[type]} {type}" for type in sorted(counts_per_type.keys())]

--- a/punchbowl/auto/control/launcher.py
+++ b/punchbowl/auto/control/launcher.py
@@ -280,8 +280,8 @@ async def launcher(pipeline_config_path=None):
         pipeline_config_path = await Variable.get("punchpipe_config", "punchpipe_config.yaml")
     pipeline_config = load_pipeline_configuration(pipeline_config_path)
     flow_weights, flow_enabled, flow_batch_sizes, flow_hosts = load_flow_data(pipeline_config)
-    logger.info(f"Enabled flows on {current_host}: {', '.join([flow for flow, enabled in flow_enabled.items()
-                                             if enabled and flow_hosts[flow] == current_host])}")
+    enabled_flows = [flow for flow, enabled in flow_enabled.items() if enabled and flow_hosts[flow] == current_host]
+    logger.info(f"Enabled flows on {current_host}: {', '.join(enabled_flows)}")
 
     logger.info("Establishing database connection")
     session = get_database_session()

--- a/punchbowl/auto/control/tests/test_launcher.py
+++ b/punchbowl/auto/control/tests/test_launcher.py
@@ -1,5 +1,6 @@
 import os
 import math
+import socket
 from datetime import UTC, datetime
 
 import pytest
@@ -8,6 +9,7 @@ from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from pytest_mock_resources import create_mysql_fixture
 
+from punchbowl.auto.cli import shorten_host
 from punchbowl.auto.control.db import Base, File, Flow
 from punchbowl.auto.control.launcher import (
     count_flows,
@@ -77,17 +79,22 @@ def flow_weights():
 def flow_batch_sizes():
     return {"level0": 1, "level1": 1}
 
+@pytest.fixture
+def flow_hosts():
+    current_host = shorten_host(socket.gethostname())
+    return {"level0": current_host, "level1": current_host}
 
-def test_gather_queued_flows(db, flow_weights, flow_batch_sizes):
+
+def test_gather_queued_flows(db, flow_weights, flow_batch_sizes, flow_hosts):
     planned_ids, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
-        db, 6, 3, flow_weights, {"level0": True, "level1": True}, flow_batch_sizes)
+        db, 6, 3, flow_weights, {"level0": True, "level1": True}, flow_batch_sizes, flow_hosts)
     assert len(planned_ids) == 3
     assert count_per_type["level0"] == 1
     assert count_per_type["level1"] == 2
     assert selected_weight == 5
     assert number_of_flows == 3
     planned_ids, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
-        db, 3, 3, flow_weights,{"level0": True, "level1": True}, flow_batch_sizes)
+        db, 3, 3, flow_weights,{"level0": True, "level1": True}, flow_batch_sizes, flow_hosts)
     assert len(planned_ids) == 2
     assert count_per_type["level0"] == 1
     assert count_per_type["level1"] == 1
@@ -95,8 +102,8 @@ def test_gather_queued_flows(db, flow_weights, flow_batch_sizes):
     assert number_of_flows == 2
 
 
-def test_count_running_flows(db, flow_weights):
-    running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights)
+def test_count_running_flows(db, flow_weights, flow_hosts):
+    running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, flow_hosts)
     assert running_count == 0
     assert planned_count == 3
     assert weight_running == 0
@@ -120,9 +127,9 @@ def test_escalate_long_waiting_flows(db):
         assert db.query(Flow).where(Flow.flow_id == 1).one().priority == 30
 
 
-def test_filter_for_launchable_flows(db, flow_weights):
+def test_filter_for_launchable_flows(db, flow_weights, flow_hosts):
     with prefect_test_harness(), disable_run_logger():
-        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights)
+        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, flow_hosts)
         max_weight_running = 30
         ready_to_launch_weight, max_flows_to_launch = determine_launchable_flow_count(
             weight_planned, weight_running, max_weight_running, math.inf, 10)
@@ -130,9 +137,9 @@ def test_filter_for_launchable_flows(db, flow_weights):
         assert max_flows_to_launch == 10
 
 
-def test_filter_for_launchable_flows_with_max_of_1(db, flow_weights, flow_batch_sizes):
+def test_filter_for_launchable_flows_with_max_of_1(db, flow_weights, flow_batch_sizes, flow_hosts):
     with prefect_test_harness(), disable_run_logger():
-        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights)
+        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, flow_hosts)
         max_weight_running = 1
         ready_to_launch_weight, max_flows_to_launch = determine_launchable_flow_count(
             weight_planned, weight_running, max_weight_running, math.inf, 10)
@@ -140,15 +147,15 @@ def test_filter_for_launchable_flows_with_max_of_1(db, flow_weights, flow_batch_
         assert max_flows_to_launch == 10
         flows, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
             db, ready_to_launch_weight, max_flows_to_launch, flow_weights, {"level0": True, "level1": True},
-            flow_batch_sizes)
+            flow_batch_sizes, flow_hosts)
         assert len(flows) == 1
         assert flows[0][0].flow_id == 3
         assert number_of_flows == 1
 
 
-def test_filter_for_launchable_flows_with_max_of_0(db, flow_weights):
+def test_filter_for_launchable_flows_with_max_of_0(db, flow_weights, flow_hosts):
     with prefect_test_harness(), disable_run_logger():
-        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights)
+        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, flow_hosts)
         max_weight_running = 0
         ready_to_launch_weight, max_flows_to_launch = determine_launchable_flow_count(
             weight_planned, weight_running, max_weight_running, math.inf, 0)
@@ -156,15 +163,11 @@ def test_filter_for_launchable_flows_with_max_of_0(db, flow_weights):
         assert max_flows_to_launch == 0
 
 
-def test_filter_for_launchable_flows_with_empty_db(db_empty, flow_weights):
+def test_filter_for_launchable_flows_with_empty_db(db_empty, flow_weights, flow_hosts):
     with prefect_test_harness(), disable_run_logger():
-        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db_empty, flow_weights)
+        running_count, planned_count, weight_planned, weight_running = count_flows.fn(db_empty, flow_weights, flow_hosts)
         max_weight_running = 30
         ready_to_launch_weight, max_flows_to_launch = determine_launchable_flow_count(
             weight_planned, weight_running, max_weight_running, math.inf, 20)
         assert ready_to_launch_weight == 0
         assert max_flows_to_launch == 20
-
-
-def test_launch_ready_flows():
-    pass

--- a/punchbowl/auto/control/tests/test_launcher.py
+++ b/punchbowl/auto/control/tests/test_launcher.py
@@ -84,6 +84,10 @@ def flow_hosts():
     current_host = shorten_host(socket.gethostname())
     return {"level0": current_host, "level1": current_host}
 
+@pytest.fixture()
+def mixed_hosts():
+    current_host = shorten_host(socket.gethostname())
+    return {"level0": current_host, "level1": "otherhost"}
 
 def test_gather_queued_flows(db, flow_weights, flow_batch_sizes, flow_hosts):
     planned_ids, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
@@ -101,6 +105,22 @@ def test_gather_queued_flows(db, flow_weights, flow_batch_sizes, flow_hosts):
     assert selected_weight == 3
     assert number_of_flows == 2
 
+def test_gather_queued_flows_with_mixed_hosts(db, flow_weights, flow_batch_sizes, mixed_hosts):
+    planned_ids, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
+        db, 6, 3, flow_weights, {"level0": True, "level1": True}, flow_batch_sizes, mixed_hosts)
+    assert len(planned_ids) == 1
+    assert count_per_type["level0"] == 1
+    assert count_per_type["level1"] == 0
+    assert selected_weight == 1
+    assert number_of_flows == 1
+    planned_ids, tags_by_flow, selected_weight, number_of_flows, count_per_type = gather_planned_flows.fn(
+        db, 3, 3, flow_weights,{"level0": True, "level1": True}, flow_batch_sizes, mixed_hosts)
+    assert len(planned_ids) == 1
+    assert count_per_type["level0"] == 1
+    assert count_per_type["level1"] == 0
+    assert selected_weight == 1
+    assert number_of_flows == 1
+
 
 def test_count_running_flows(db, flow_weights, flow_hosts):
     running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, flow_hosts)
@@ -109,6 +129,12 @@ def test_count_running_flows(db, flow_weights, flow_hosts):
     assert weight_running == 0
     assert weight_planned == 5
 
+def test_count_running_flows_with_mixed_hosts(db, flow_weights, mixed_hosts):
+    running_count, planned_count, weight_planned, weight_running = count_flows.fn(db, flow_weights, mixed_hosts)
+    assert running_count == 0
+    assert planned_count == 1
+    assert weight_running == 0
+    assert weight_planned == 1
 
 def test_escalate_long_waiting_flows(db):
     pipeline_config_path = os.path.join(TEST_DIR, "punchpipe_config.yaml")

--- a/punchbowl/auto/monitor/pages/home.py
+++ b/punchbowl/auto/monitor/pages/home.py
@@ -58,8 +58,9 @@ def layout():
                 ),
                 dcc.Dropdown(
                     id="host-selector",
-                    options=["phoenix", "chimera"],
-                    value="phoenix",
+                    options=["phoenix.spaceops.swri.org",
+                             "chimera.spaceops.swri.org"],
+                    value="phoenix.spaceops.swri.org",
                     clearable=False,
                     style={"width": "50%"},
                     persistence=True, persistence_type="memory"

--- a/punchbowl/auto/monitor/pages/home.py
+++ b/punchbowl/auto/monitor/pages/home.py
@@ -56,6 +56,14 @@ def layout():
                     style={"width": "50%"},
                     persistence=True, persistence_type="memory",
                 ),
+                dcc.Dropdown(
+                    id="host-selector",
+                    options=["phoenix", "chimera"],
+                    value="phoenix",
+                    clearable=False,
+                    style={"width": "50%"},
+                    persistence=True, persistence_type="memory"
+                )
             ]),
         ]),
         html.Hr(),
@@ -309,8 +317,9 @@ def update_file_cards(n):
     Input("plot-range", "start_date"),
     Input("plot-range", "end_date"),
     Input("machine-stat-smoothing", "value"),
+    Input("host-selector", "host")
 )
-def update_machine_stats(n, machine_stat, start_date, end_date, smooth_window):
+def update_machine_stats(n, machine_stat, start_date, end_date, smooth_window, host):
     axis_labels = {"cpu_usage": "CPU Usage %",
                    "memory_usage": "Memory Usage[GB]",
                    "memory_percentage": "Memory Usage %",
@@ -318,7 +327,10 @@ def update_machine_stats(n, machine_stat, start_date, end_date, smooth_window):
                    "disk_percentage": "Disk Usage %",
                    "num_pids": "Process Count"}
 
-    query = select(Health).where(Health.datetime > start_date).where(Health.datetime < end_date)
+    query = (select(Health)
+             .where(Health.datetime > start_date)
+             .where(Health.datetime < end_date)
+             .where(Health.host == host))
     with get_database_session() as session:
         df = pd.read_sql_query(query, session.connection())
 


### PR DESCRIPTION
- Allows deploying only enabled flows on a server
- Adds host tracking to health stats
- Allow duplicating control flows by host, e.g. "launcher-chimera" runs on chimera while "launcher-phoenix" runs on phoenix