### PR TITLE
Modify filename in cube metadata in place

### DIFF
--- a/changelog/863.bugfix.rst
+++ b/changelog/863.bugfix.rst
@@ -1,0 +1,1 @@
+Corrects filename in quicklook metadata.

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -295,10 +295,11 @@ def write_ndcube_to_fits(cube: NDCube,
         )
         raise ValueError(msg)
 
+    cube.meta["FILENAME"] = os.path.basename(filename)
+
     meta = cube.meta if skip_stats else _update_statistics(cube)
 
     full_header = meta.to_fits_header(wcs=cube.wcs, write_celestial_wcs=not skip_wcs_conversion)
-    full_header["FILENAME"] = os.path.basename(filename)
 
     hdu_data = fits.CompImageHDU(data=cube.data.astype(np.float32) if cube.data.dtype == np.float64 else cube.data,
                                  header=full_header,


### PR DESCRIPTION
Quicklook data products contained incorrect filenames in their metadata. This modifies the cube metadata in place when writing to file, using the updated filename, fixing downstream when the quicklook file is written from that cube.