### PR TITLE
Set the level 0 polaroff keyword

### DIFF
--- a/changelog/887.bugfix.rst
+++ b/changelog/887.bugfix.rst
@@ -1,0 +1,1 @@
+Sets the polaroff keyword to 90 for level 0 products.

--- a/punchbowl/data/data/Level0.yaml
+++ b/punchbowl/data/data/Level0.yaml
@@ -41,6 +41,7 @@ Kinds:
             NAXIS1: 2048
             NAXIS2: 2048
             POLARREF: 'Instrument'
+            POLAROFF: 90
         omits: [NAXIS3]
 
     Unpolarized:


### PR DESCRIPTION
Our reference angle is always 90 degrees so we should set it for level 0 as well