### PR TITLE
Uncompressed movie scaling

### DIFF
--- a/changelog/912.bugfix.rst
+++ b/changelog/912.bugfix.rst
@@ -1,0 +1,1 @@
+When non-square-root-compressed data is acquired, appropriately scale the color bar range in the daily movies.

--- a/punchbowl/auto/flows/visualize.py
+++ b/punchbowl/auto/flows/visualize.py
@@ -127,9 +127,11 @@ def movie_core_flow(file_list: list, product_code: str, output_movie_dir: str,
 
             vmin, vmax = load_quicklook_scaling(level=cube.meta["LEVEL"].value, product=cube.meta["TYPECODE"].value, obscode=cube.meta["OBSCODE"].value)
 
-            if cube.meta["LEVEL"].value == "0" and cube.meta["ISSQRT"].value == 0:
-                vmin = vmin**2
-                vmax = vmax**2
+            if cube.meta["LEVEL"].value == "0" and cube.meta["ISSQRT"].value == 0 and cube.meta['SCALE'].value != 0:
+                # The values in the config file are sqrt-encoded, so need to undo it. SCALE is only used in
+                # sqrt-encoded data, but this assumes the value is not changed when sqrting is turned off.
+                vmin = vmin**2 / cube.meta['SCALE'].value
+                vmax = vmax**2 / cube.meta['SCALE'].value
 
             write_ndcube_to_quicklook(cube, filename=img_file, annotation=annotation, vmin=vmin, vmax=vmax)
 

--- a/punchbowl/auto/flows/visualize.py
+++ b/punchbowl/auto/flows/visualize.py
@@ -127,7 +127,7 @@ def movie_core_flow(file_list: list, product_code: str, output_movie_dir: str,
 
             vmin, vmax = load_quicklook_scaling(level=cube.meta["LEVEL"].value, product=cube.meta["TYPECODE"].value, obscode=cube.meta["OBSCODE"].value)
 
-            if cube.meta["LEVEL"].value == 0 and cube.meta["ISSQRT"].value == 0:
+            if cube.meta["LEVEL"].value == "0" and cube.meta["ISSQRT"].value == 0:
                 vmin = vmin**2
                 vmax = vmax**2
 


### PR DESCRIPTION
## PR summary

Scale uncompressed data properly when making the daily quicklook movies

## Test plan

*How does this PR verify the code works correctly?*
See saturated image in #911.
This is what happens when the Level==0 is changed to Level=="0":
<img width="989" height="1023" alt="Squared VminVmax" src="https://github.com/user-attachments/assets/d587dfa4-a5e3-4c11-899d-b39e3dd6f0ab" />
This is what happens when the scaling is applied after the squaring:
<img width="989" height="1023" alt="Squared-and-Scaled VminVmax" src="https://github.com/user-attachments/assets/375cd976-ee19-47c4-a70e-c3a7ff449bbc" />


## Breaking changes

None known. I have not been able to test this on uncompressed NFI data.

## Related Issues

Fixes #911.
