### PR TITLE
Make alignment faster

### DIFF
--- a/changelog/940.feature.rst
+++ b/changelog/940.feature.rst
@@ -1,0 +1,1 @@
+Alignment uses a median of the iterations that are run, allowing much fewer iterations to be used.

--- a/punchbowl/auto/flows/level1.py
+++ b/punchbowl/auto/flows/level1.py
@@ -619,6 +619,7 @@ def level1_early_construct_flow_info(level0_files: list[File], level1_files: lis
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
             "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
+            "n_alignment_iterations": pipeline_config["flows"][flow_type].get("n_alignment_iterations", 50),
         },
     )
     return Flow(
@@ -661,6 +662,7 @@ def level1_early_construct_flow_info_phoenix(level0_files: list[File], level1_fi
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
             "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
+            "n_alignment_iterations": pipeline_config["flows"][flow_type].get("n_alignment_iterations", 50),
         },
     )
     return Flow(
@@ -704,6 +706,7 @@ def level1_early_construct_flow_info_chimera(level0_files: list[File], level1_fi
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
             "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
+            "n_alignment_iterations": pipeline_config["flows"][flow_type].get("n_alignment_iterations", 50),
         },
     )
     return Flow(

--- a/punchbowl/auto/flows/level1.py
+++ b/punchbowl/auto/flows/level1.py
@@ -618,6 +618,7 @@ def level1_early_construct_flow_info(level0_files: list[File], level1_files: lis
             "mask_path": mask_function.filename().replace(".fits", ".bin"),
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
+            "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
         },
     )
     return Flow(
@@ -659,6 +660,7 @@ def level1_early_construct_flow_info_phoenix(level0_files: list[File], level1_fi
             "mask_path": mask_function.filename().replace(".fits", ".bin"),
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
+            "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
         },
     )
     return Flow(
@@ -701,6 +703,7 @@ def level1_early_construct_flow_info_chimera(level0_files: list[File], level1_fi
             "mask_path": mask_function.filename().replace(".fits", ".bin"),
             "psf_model_path": best_psf_model,
             "distortion_path": best_distortion.filename(),
+            "n_alignment_workers": pipeline_config["flows"][flow_type].get("n_alignment_workers", 3),
         },
     )
     return Flow(

--- a/punchbowl/level1/alignment.py
+++ b/punchbowl/level1/alignment.py
@@ -363,7 +363,7 @@ def convert_cd_matrix_to_pc_matrix(wcs: WCS) -> WCS:
     return new_wcs
 
 
-def solve_pointing(
+def solve_pointing( # noqa: C901
         image_data: np.ndarray,
         image_wcs: WCS,
         image_header: NormalizedMetadata,
@@ -481,7 +481,23 @@ def solve_pointing(
     solved_wcs = guess_wcs
     cdelt = np.median(platescales)
     solved_wcs.wcs.cdelt = -cdelt, cdelt
-    solved_wcs.wcs.crval = np.median(crval1s), np.median(crval2s)
+
+    crval1s = np.array(crval1s)
+    if np.any(crval1s < 5) and np.any(crval1s > 355):
+        # We're straddling the wrap point, at 360 -> 0 deg
+        # Shift the high values down to -180-or-so
+        crval1s[crval1s > 180] -= 360
+        crval1 = np.median(crval1s)
+        crval1 %= 360
+    else:
+        crval1 = np.median(crval1s)
+
+    solved_wcs.wcs.crval = crval1, np.median(crval2s)
+    crotas = np.array(crotas)
+    if np.any(crotas < -170 * np.pi / 180) and np.any(crotas > 170 * np.pi / 180):
+        # We're straddling the wrap point, at 180 -> -180 deg
+        # Shift the negative values up to 180 + change
+        crotas %= 2 * np.pi
     crota = np.median(crotas)
     solved_wcs.wcs.pc = np.array(
         [

--- a/punchbowl/level1/alignment.py
+++ b/punchbowl/level1/alignment.py
@@ -14,7 +14,6 @@ import sep
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS, DistortionLookupTable, NoConvergence, utils
-from lmfit import Parameters, minimize
 from ndcube import NDCube
 from prefect import get_run_logger
 from regularizepsf import ArrayPSFTransform
@@ -23,6 +22,7 @@ from skimage.transform import resize
 
 from punchbowl.data import NormalizedMetadata
 from punchbowl.data.wcs import calculate_celestial_wcs_from_helio, calculate_helio_wcs_from_celestial
+from punchbowl.level1.alignment_parallel import get_errors, refine_pointing_single_step
 from punchbowl.prefect import punch_task
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -339,78 +339,7 @@ def astrometry_net_initial_solve(observed_coords: np.ndarray,
         return None
 
 
-def _residual(params: Parameters,
-              catalog_stars: SkyCoord,
-              observed_tree: KDTree,
-              guess_wcs: WCS,
-              max_error: float = 30) -> float:
-    """
-    Residual used when optimizing the pointing.
 
-    Parameters
-    ----------
-    params : Parameters
-        optimization parameters from lmfit
-    catalog_stars : SkyCoord
-        image catalog of stars to match against
-    observed_tree : KDTree
-        a KDTree of the pixel coordinates of the observed stars
-    guess_wcs : WCS
-        initial guess of the world coordinate system, must overlap with the true WCS
-    max_error: float
-        stars more distant than this are complete misses, and their error is zeroed out
-
-    Returns
-    -------
-    np.ndarray
-        residual
-
-    """
-    refined_wcs = guess_wcs.deepcopy()
-    refined_wcs.wcs.cdelt = (-params["platescale"].value, params["platescale"].value)
-    refined_wcs.wcs.crval = (params["crval1"].value, params["crval2"].value)
-    refined_wcs.wcs.pc = np.array(
-        [
-            [np.cos(params["crota"]), -np.sin(params["crota"])],
-            [np.sin(params["crota"]), np.cos(params["crota"])],
-        ],
-    )
-    refined_wcs.cpdis1 = guess_wcs.cpdis1
-    refined_wcs.cpdis2 = guess_wcs.cpdis2
-
-    errors, _ = get_errors(refined_wcs, catalog_stars, observed_tree)
-    errors = errors[errors < max_error]
-    return np.nansum(np.abs(errors)) / len(errors)
-
-
-def get_errors(wcs: WCS, catalog_stars: SkyCoord | tuple[np.ndarray, np.ndarray],
-               observed_stars: np.ndarray | KDTree) -> tuple[np.ndarray, np.ndarray]:
-    """Compute errors between expected and observed star locations."""
-    if isinstance(observed_stars, np.ndarray):
-        observed_stars = KDTree(observed_stars)
-    if isinstance(catalog_stars, SkyCoord):
-        try:
-            xs, ys = catalog_stars.to_pixel(wcs, mode="all")
-        except NoConvergence as e:
-            xs, ys = e.best_solution[:, 0], e.best_solution[:, 1]
-    else:
-        xs, ys = catalog_stars
-    refined_coords = np.stack([xs, ys], axis=-1)
-
-    errors = np.empty(refined_coords.shape[0])
-    closest_stars = np.empty(refined_coords.shape)
-    for coord_i, coord in enumerate(refined_coords):
-        dd, ii = observed_stars.query(coord, k=1)
-        errors[coord_i] = dd
-        closest_stars[coord_i] = observed_stars.data[ii]
-
-    return errors, closest_stars
-
-
-def extract_crota_from_wcs(wcs: WCS) -> tuple[float, float]:
-    """Extract CROTA from a WCS."""
-    delta_ratio = abs(wcs.wcs.cdelt[1]) / abs(wcs.wcs.cdelt[0])
-    return (np.arctan2(wcs.wcs.pc[1, 0] / delta_ratio, wcs.wcs.pc[0, 0])) * u.rad
 
 
 def convert_cd_matrix_to_pc_matrix(wcs: WCS) -> WCS:
@@ -432,74 +361,6 @@ def convert_cd_matrix_to_pc_matrix(wcs: WCS) -> WCS:
     new_wcs.wcs.cdelt = (-cdelt1, cdelt2)
     new_wcs.wcs.cunit = "deg", "deg"
     return new_wcs
-
-
-def refine_pointing_single_step(
-        guess_wcs: WCS, observed_tree: KDTree, catalog_stars: SkyCoord, method: str = "least_squares",
-        ra_tolerance: float = 10, dec_tolerance: float = 5,
-        fix_crval: bool = False, fix_crota: bool = False, fix_pv: bool = True) -> WCS:
-    """
-    Perform a single step of pointing refinement.
-
-    Parameters
-    ----------
-    guess_wcs : WCS
-        the initial guess for the world coordinate system
-    observed_tree: KDTree
-        coordinates of the observed star positions extracted from the image, as a tree
-    catalog_stars : SkyCoord
-        the coordinates of known stars to be matched with the observed stars
-    method : str
-        method used by lmfit for minimization
-    ra_tolerance : float
-        how many degrees the guess WCS is allowed to be incorrect by in right ascension
-    dec_tolerance : float
-        how many degrees the guess WCS is allowed to be incorrect by in declination
-    fix_crval : bool
-        if True the crval is not allowed to vary, otherwise it can be fit
-    fix_crota : bool
-        if True the crota is not allowed to vary, otherwise it can be fit
-    fix_pv : bool
-        if True the pv is not allowed to vary, otherwise it can be fit
-
-    Returns
-    -------
-    WCS
-        the new world coordinate system
-
-    """
-    # set up the optimization
-    params = Parameters()
-    initial_crota = extract_crota_from_wcs(guess_wcs)
-    params.add("crota", value=initial_crota.to(u.rad).value,
-               min=-np.pi, max=np.pi, vary=not fix_crota)
-    params.add("crval1", value=guess_wcs.wcs.crval[0],
-               min=guess_wcs.wcs.crval[0] - ra_tolerance,
-               max=guess_wcs.wcs.crval[0] + ra_tolerance, vary=not fix_crval)
-    params.add("crval2", value=guess_wcs.wcs.crval[1],
-               min=guess_wcs.wcs.crval[1] - dec_tolerance,
-               max=guess_wcs.wcs.crval[1] + dec_tolerance, vary=not fix_crval)
-    params.add("platescale", value=abs(guess_wcs.wcs.cdelt[0]), min=0, max=1, vary=False)
-    pv = guess_wcs.wcs.get_pv()[0][-1] if guess_wcs.wcs.get_pv() else 0.0
-    params.add("pv", value=pv, min=0.0, max=1.0, vary=not fix_pv)
-
-    out = minimize(_residual, params, method=method,
-                   args=(catalog_stars, observed_tree, guess_wcs),
-                   max_nfev=1000, calc_covar=False)
-    result_wcs = guess_wcs.deepcopy()
-    result_wcs.wcs.cdelt = (-out.params["platescale"].value, out.params["platescale"].value)
-    result_wcs.wcs.crval = (out.params["crval1"].value, out.params["crval2"].value)
-    result_wcs.wcs.pc = np.array(
-        [
-            [np.cos(out.params["crota"].value), -np.sin(out.params["crota"].value)],
-            [np.sin(out.params["crota"].value), np.cos(out.params["crota"].value)],
-        ],
-    )
-    result_wcs.cpdis1 = guess_wcs.cpdis1
-    result_wcs.cpdis2 = guess_wcs.cpdis2
-    result_wcs.wcs.set_pv([(2, 1, out.params["pv"].value)])
-
-    return result_wcs, out.residual[0]
 
 
 def solve_pointing(

--- a/punchbowl/level1/alignment.py
+++ b/punchbowl/level1/alignment.py
@@ -370,7 +370,7 @@ def solve_pointing(
         distortion: WCS | None = None,
         saturation_limit: float = np.inf,
         observatory: str = "wfi",
-        n_rounds: int = 175,
+        n_rounds: int = 50,
         n_workers: int = 4) -> WCS:
     """
     Carefully determine the pointing of an image using the starfield.
@@ -638,7 +638,8 @@ def build_distortion_model(
 
 
 @punch_task
-def align_task(data_object: NDCube, distortion_path: str | None, max_workers: int = 4) -> NDCube:
+def align_task(data_object: NDCube, distortion_path: str | None, max_workers: int = 4,
+               n_rounds: int = 50) -> NDCube:
     """
     Determine the pointing of the image and updates the metadata appropriately.
 
@@ -650,6 +651,8 @@ def align_task(data_object: NDCube, distortion_path: str | None, max_workers: in
         path to a distortion model
     max_workers : int
         number of parallel workers to use
+    n_rounds : int
+        number of iterations for alignment
 
     Returns
     -------
@@ -676,7 +679,8 @@ def align_task(data_object: NDCube, distortion_path: str | None, max_workers: in
 
     observatory = "nfi" if data_object.meta["OBSCODE"].value == "4" else "wfi"
     celestial_output = solve_pointing(refining_data, celestial_input, data_object.meta, distortion,
-                                      saturation_limit=60_000, observatory=observatory, n_workers=max_workers)
+                                      saturation_limit=60_000, observatory=observatory, n_workers=max_workers,
+                                      n_rounds=n_rounds)
 
     recovered_wcs = calculate_helio_wcs_from_celestial(celestial_output,
                                                        data_object.meta.astropy_time,

--- a/punchbowl/level1/alignment.py
+++ b/punchbowl/level1/alignment.py
@@ -468,22 +468,28 @@ def solve_pointing(
 
     indices = np.arange(len(catalog_stars))
     rng = np.random.default_rng(seed=1)
-    candidate_wcs = []
+    results = []
     observed_tree = KDTree(observed)
     mp_context = multiprocessing.get_context("forkserver")
     with ProcessPoolExecutor(n_workers, mp_context) as p:
         for _ in range(n_rounds):
             sample = catalog_stars[rng.choice(indices, 15, replace=False)]
-            candidate_wcs.append(p.submit(refine_pointing_single_step, guess_wcs, observed_tree, sample, fix_pv=True))
-    candidate_wcs = [w.result() for w in candidate_wcs]
-    errors = [r[1] for r in candidate_wcs]
-    candidate_wcs = [r[0] for r in candidate_wcs]
-    best = np.argmin(np.abs(errors))
+            results.append(p.submit(refine_pointing_single_step, guess_wcs, observed_tree, sample, fix_pv=True))
+    results = [w.result() for w in results]
 
-    solved_wcs = candidate_wcs[best]
-    if distortion is not None:
-        solved_wcs.cpdis1 = distortion.cpdis1
-        solved_wcs.cpdis2 = distortion.cpdis2
+    platescales, crval1s, crval2s, crotas, pvs = zip(*results, strict=True)
+    solved_wcs = guess_wcs
+    cdelt = np.median(platescales)
+    solved_wcs.wcs.cdelt = -cdelt, cdelt
+    solved_wcs.wcs.crval = np.median(crval1s), np.median(crval2s)
+    crota = np.median(crotas)
+    solved_wcs.wcs.pc = np.array(
+        [
+            [np.cos(crota), -np.sin(crota)],
+            [np.sin(crota), np.cos(crota)],
+        ],
+    )
+    solved_wcs.wcs.set_pv([(2, 1, np.median(pvs))])
 
     return solved_wcs
 
@@ -701,5 +707,5 @@ def align_task(data_object: NDCube, distortion_path: str | None, max_workers: in
                     uncertainty=data_object.uncertainty,
                     unit=data_object.unit,
                     meta=data_object.meta)
-    output.meta.history.add_now("LEVEL1-Align", "alignment done")
+    output.meta.history.add_now("LEVEL1-Align", f"alignment done with {n_rounds} iterations")
     return output

--- a/punchbowl/level1/alignment_parallel.py
+++ b/punchbowl/level1/alignment_parallel.py
@@ -95,19 +95,18 @@ def _residual(params: Parameters,
         residual
 
     """
-    refined_wcs = guess_wcs.deepcopy()
-    refined_wcs.wcs.cdelt = (-params["platescale"].value, params["platescale"].value)
-    refined_wcs.wcs.crval = (params["crval1"].value, params["crval2"].value)
-    refined_wcs.wcs.pc = np.array(
+    guess_wcs.wcs.cdelt = (-params["platescale"].value, params["platescale"].value)
+    guess_wcs.wcs.crval = (params["crval1"].value, params["crval2"].value)
+    guess_wcs.wcs.pc = np.array(
         [
             [np.cos(params["crota"]), -np.sin(params["crota"])],
             [np.sin(params["crota"]), np.cos(params["crota"])],
         ],
     )
-    refined_wcs.cpdis1 = guess_wcs.cpdis1
-    refined_wcs.cpdis2 = guess_wcs.cpdis2
+    guess_wcs.cpdis1 = guess_wcs.cpdis1
+    guess_wcs.cpdis2 = guess_wcs.cpdis2
 
-    errors, _ = get_errors(refined_wcs, catalog_stars, observed_tree)
+    errors, _ = get_errors(guess_wcs, catalog_stars, observed_tree)
     errors = errors[errors < max_error]
     return np.nansum(np.abs(errors)) / len(errors)
 

--- a/punchbowl/level1/alignment_parallel.py
+++ b/punchbowl/level1/alignment_parallel.py
@@ -1,0 +1,154 @@
+# This is the alignment code that's run by the parallel workers. Since we can't fork under prefect, each worker has
+# to freshly import the file containing the code it'll run. By moving the code into its own file, we cut the number
+# of imports. Each worker's import work drops from ~4.5 s to ~3 s by doing this.
+
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS, NoConvergence
+from lmfit import Parameters, minimize
+from scipy.spatial import KDTree
+
+
+def refine_pointing_single_step(
+        guess_wcs: WCS, observed_tree: KDTree, catalog_stars: SkyCoord, method: str = "least_squares",
+        ra_tolerance: float = 10, dec_tolerance: float = 5,
+        fix_crval: bool = False, fix_crota: bool = False, fix_pv: bool = True) -> WCS:
+    """
+    Perform a single step of pointing refinement.
+
+    Parameters
+    ----------
+    guess_wcs : WCS
+        the initial guess for the world coordinate system
+    observed_tree: KDTree
+        coordinates of the observed star positions extracted from the image, as a tree
+    catalog_stars : SkyCoord
+        the coordinates of known stars to be matched with the observed stars
+    method : str
+        method used by lmfit for minimization
+    ra_tolerance : float
+        how many degrees the guess WCS is allowed to be incorrect by in right ascension
+    dec_tolerance : float
+        how many degrees the guess WCS is allowed to be incorrect by in declination
+    fix_crval : bool
+        if True the crval is not allowed to vary, otherwise it can be fit
+    fix_crota : bool
+        if True the crota is not allowed to vary, otherwise it can be fit
+    fix_pv : bool
+        if True the pv is not allowed to vary, otherwise it can be fit
+
+    Returns
+    -------
+    WCS
+        the new world coordinate system
+
+    """
+    # set up the optimization
+    params = Parameters()
+    initial_crota = extract_crota_from_wcs(guess_wcs)
+    params.add("crota", value=initial_crota.to(u.rad).value,
+               min=-np.pi, max=np.pi, vary=not fix_crota)
+    params.add("crval1", value=guess_wcs.wcs.crval[0],
+               min=guess_wcs.wcs.crval[0] - ra_tolerance,
+               max=guess_wcs.wcs.crval[0] + ra_tolerance, vary=not fix_crval)
+    params.add("crval2", value=guess_wcs.wcs.crval[1],
+               min=guess_wcs.wcs.crval[1] - dec_tolerance,
+               max=guess_wcs.wcs.crval[1] + dec_tolerance, vary=not fix_crval)
+    params.add("platescale", value=abs(guess_wcs.wcs.cdelt[0]), min=0, max=1, vary=False)
+    pv = guess_wcs.wcs.get_pv()[0][-1] if guess_wcs.wcs.get_pv() else 0.0
+    params.add("pv", value=pv, min=0.0, max=1.0, vary=not fix_pv)
+
+    with np.errstate(all="ignore"):
+        out = minimize(_residual, params, method=method,
+                       args=(catalog_stars, observed_tree, guess_wcs),
+                       max_nfev=1000, calc_covar=False)
+    result_wcs = guess_wcs.deepcopy()
+    result_wcs.wcs.cdelt = (-out.params["platescale"].value, out.params["platescale"].value)
+    result_wcs.wcs.crval = (out.params["crval1"].value, out.params["crval2"].value)
+    result_wcs.wcs.pc = np.array(
+        [
+            [np.cos(out.params["crota"].value), -np.sin(out.params["crota"].value)],
+            [np.sin(out.params["crota"].value), np.cos(out.params["crota"].value)],
+        ],
+    )
+    result_wcs.cpdis1 = guess_wcs.cpdis1
+    result_wcs.cpdis2 = guess_wcs.cpdis2
+    result_wcs.wcs.set_pv([(2, 1, out.params["pv"].value)])
+
+    return result_wcs, out.residual[0]
+
+
+def _residual(params: Parameters,
+              catalog_stars: SkyCoord,
+              observed_tree: KDTree,
+              guess_wcs: WCS,
+              max_error: float = 30) -> float:
+    """
+    Residual used when optimizing the pointing.
+
+    Parameters
+    ----------
+    params : Parameters
+        optimization parameters from lmfit
+    catalog_stars : SkyCoord
+        image catalog of stars to match against
+    observed_tree : KDTree
+        a KDTree of the pixel coordinates of the observed stars
+    guess_wcs : WCS
+        initial guess of the world coordinate system, must overlap with the true WCS
+    max_error: float
+        stars more distant than this are complete misses, and their error is zeroed out
+
+    Returns
+    -------
+    np.ndarray
+        residual
+
+    """
+    refined_wcs = guess_wcs.deepcopy()
+    refined_wcs.wcs.cdelt = (-params["platescale"].value, params["platescale"].value)
+    refined_wcs.wcs.crval = (params["crval1"].value, params["crval2"].value)
+    refined_wcs.wcs.pc = np.array(
+        [
+            [np.cos(params["crota"]), -np.sin(params["crota"])],
+            [np.sin(params["crota"]), np.cos(params["crota"])],
+        ],
+    )
+    refined_wcs.cpdis1 = guess_wcs.cpdis1
+    refined_wcs.cpdis2 = guess_wcs.cpdis2
+
+    errors, _ = get_errors(refined_wcs, catalog_stars, observed_tree)
+    errors = errors[errors < max_error]
+    return np.nansum(np.abs(errors)) / len(errors)
+
+
+def get_errors(wcs: WCS, catalog_stars: SkyCoord | tuple[np.ndarray, np.ndarray],
+               observed_stars: np.ndarray | KDTree) -> tuple[np.ndarray, np.ndarray]:
+    """Compute errors between expected and observed star locations."""
+    if isinstance(observed_stars, np.ndarray):
+        observed_stars = KDTree(observed_stars)
+    if isinstance(catalog_stars, SkyCoord):
+        try:
+            xs, ys = catalog_stars.to_pixel(wcs, mode="all")
+        except NoConvergence as e:
+            xs, ys = e.best_solution[:, 0], e.best_solution[:, 1]
+    else:
+        xs, ys = catalog_stars
+    refined_coords = np.stack([xs, ys], axis=-1)
+
+    errors = np.empty(refined_coords.shape[0])
+    closest_stars = np.empty(refined_coords.shape)
+    for coord_i, coord in enumerate(refined_coords):
+        dd, ii = observed_stars.query(coord, k=1)
+        errors[coord_i] = dd
+        closest_stars[coord_i] = observed_stars.data[ii]
+
+    return errors, closest_stars
+
+
+def extract_crota_from_wcs(wcs: WCS) -> tuple[float, float]:
+    """Extract CROTA from a WCS."""
+    delta_ratio = abs(wcs.wcs.cdelt[1]) / abs(wcs.wcs.cdelt[0])
+    return (np.arctan2(wcs.wcs.pc[1, 0] / delta_ratio, wcs.wcs.pc[0, 0])) * u.rad

--- a/punchbowl/level1/alignment_parallel.py
+++ b/punchbowl/level1/alignment_parallel.py
@@ -64,20 +64,8 @@ def refine_pointing_single_step(
         out = minimize(_residual, params, method=method,
                        args=(catalog_stars, observed_tree, guess_wcs),
                        max_nfev=1000, calc_covar=False)
-    result_wcs = guess_wcs.deepcopy()
-    result_wcs.wcs.cdelt = (-out.params["platescale"].value, out.params["platescale"].value)
-    result_wcs.wcs.crval = (out.params["crval1"].value, out.params["crval2"].value)
-    result_wcs.wcs.pc = np.array(
-        [
-            [np.cos(out.params["crota"].value), -np.sin(out.params["crota"].value)],
-            [np.sin(out.params["crota"].value), np.cos(out.params["crota"].value)],
-        ],
-    )
-    result_wcs.cpdis1 = guess_wcs.cpdis1
-    result_wcs.cpdis2 = guess_wcs.cpdis2
-    result_wcs.wcs.set_pv([(2, 1, out.params["pv"].value)])
-
-    return result_wcs, out.residual[0]
+    return (out.params["platescale"].value, out.params["crval1"].value, out.params["crval2"].value,
+            out.params["crota"].value, out.params["pv"].value)
 
 
 def _residual(params: Parameters,

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -76,6 +76,7 @@ def level1_early_core_flow(  # noqa: C901
     psf_model_path: str | DataLoader | None = None,
     max_workers: int | None = None,
     n_alignment_workers: int | None = None,
+    n_alignment_iterations: int = 50,
     output_filename: list[str] | None = None,
     mask_path: str | None = None,
 ) -> list[NDCube]:
@@ -168,7 +169,8 @@ def level1_early_core_flow(  # noqa: C901
                 data.meta.history.add_now("LEVEL1-align", "Image has bad packets; no alignment applied")
                 logger.info("Bad packets---alignment skipped")
             else:
-                data = align_task(data, distortion_path, max_workers=n_alignment_workers or max_workers)
+                data = align_task(data, distortion_path, max_workers=n_alignment_workers or max_workers,
+                                  n_rounds=n_alignment_iterations)
 
         if mask is not None:
             data.data[~mask] = 0

--- a/punchbowl/level1/flow.py
+++ b/punchbowl/level1/flow.py
@@ -75,6 +75,7 @@ def level1_early_core_flow(  # noqa: C901
     distortion_path: str | None = None,
     psf_model_path: str | DataLoader | None = None,
     max_workers: int | None = None,
+    n_alignment_workers: int | None = None,
     output_filename: list[str] | None = None,
     mask_path: str | None = None,
 ) -> list[NDCube]:
@@ -167,7 +168,7 @@ def level1_early_core_flow(  # noqa: C901
                 data.meta.history.add_now("LEVEL1-align", "Image has bad packets; no alignment applied")
                 logger.info("Bad packets---alignment skipped")
             else:
-                data = align_task(data, distortion_path, max_workers=max_workers)
+                data = align_task(data, distortion_path, max_workers=n_alignment_workers or max_workers)
 
         if mask is not None:
             data.data[~mask] = 0


### PR DESCRIPTION
This makes the alignment code run in about 1/3 the time at the same core count (and I think we can use a few more cores---it's configurable now!).

For a typical image, we had been runing 175 iterations, each finding a best-fit WCS for a small subset of catalog stars, and we used the single WCS which reported the lowest RMS error for its subset of stars. Across all iterations, the spread of fitted CRVALs looks like this:
<img width="625" height="615" alt="image" src="https://github.com/user-attachments/assets/1264ca75-0b9b-478c-9c33-637d01017493" />
The color is the reported RMS error for that WCS's subset, and it noticeably doesn't really trend with distance to the center of the CRVAL cloud. If we assume the cloud center is the true answer, I bet these residuals are dominated by error in the identified star centroids, and so there's nothing special about the one fit with the lowest residual. This PR changes to using the median CRVAL and CROTA across the iterations.

With that in place, we can run a lot fewer iterations. We can compare the median WCS we get after 50 iterations to what we get after 175 iterations, by taking a set of pixels at the image edges and going pixel --wcs1-> world --wcs2-> pixel and computing the RMS difference i pixels. That distribution, over 20,000 WFI images, looks like this:
<img width="720" height="576" alt="image" src="https://github.com/user-attachments/assets/d110ea70-0c45-41e2-8655-dd859bd9ebd9" />

So 50 iterations looks basically as good as 175. That's the bulk of the speedup here.

This also reduces import overhead for the parallel workers. For one worker, startup time goes from ~4s to 2.5s.