### PR TITLE
Write satellite positons and velocities correctly

### DIFF
--- a/changelog/951.bugfix.rst
+++ b/changelog/951.bugfix.rst
@@ -1,0 +1,1 @@
+Spacecraft positions are written correctly in the FITS headers. (Previously, the rotation of the reference frame with Earth was not handled correctly.)

--- a/changelog/951.feature.rst
+++ b/changelog/951.feature.rst
@@ -1,0 +1,1 @@
+Spacecraft velocities are now written correctly in L0 and used in alignment.

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import pylibjpeg
 import quaternion
-from astropy.coordinates import GCRS, EarthLocation, HeliocentricMeanEcliptic, SkyCoord
+from astropy.coordinates import GCRS, CartesianDifferential, EarthLocation, HeliocentricMeanEcliptic, SkyCoord
 from astropy.time import Time, TimeDelta
 from astropy.wcs import WCS
 from ccsdspy import PacketArray, PacketField, converters
@@ -497,16 +497,24 @@ def organize_ceb_fits_keywords(ceb_packet_db, ceb_packet):
 
 
 def organize_spacecraft_position_keywords(observation_time, before_xact_db, before_xact):
-    position = EarthLocation.from_geocentric(before_xact["GPS_POSITION_ECEF1"]*2E-5*u.km,
-                                             before_xact["GPS_POSITION_ECEF2"]*2E-5*u.km,
-                                             before_xact["GPS_POSITION_ECEF3"]*2E-5*u.km)
-
-    location = EarthLocation.from_geodetic(position.geodetic.lon.deg,
-                                           position.geodetic.lat.deg,
-                                           position.geodetic.height.to(u.m).value)
     obstime = Time(observation_time)
+    # This packages up the coordinates, but does no frame conversions. The scale factor is given in the big
+    # PUNCH_TLM.xls spreadsheet.
+    position = EarthLocation.from_geocentric(before_xact["GPS_POSITION_ECEF1"] * 2E-5 * u.km,
+                                             before_xact["GPS_POSITION_ECEF2"] * 2E-5 * u.km,
+                                             before_xact["GPS_POSITION_ECEF3"] * 2E-5 * u.km)
 
-    gcrs = GCRS(location.get_itrs(obstime).cartesian, obstime=obstime)
+    velocity = CartesianDifferential(
+        before_xact["GPS_VELOCITY_ECEF1"] * 5E-9 * u.km / u.s,
+        before_xact["GPS_VELOCITY_ECEF2"] * 5E-9 * u.km / u.s,
+        before_xact["GPS_VELOCITY_ECEF3"] * 5E-9 * u.km / u.s)
+
+    # Re-create with velocity attached
+    itrs = position.get_itrs(obstime)
+    newdata = itrs.data.to_cartesian().with_differentials(velocity)
+    itrs = itrs.realize_frame(newdata)
+
+    gcrs = itrs.transform_to(GCRS(obstime=obstime))
     hci = gcrs.transform_to(HeliocentricInertial(obstime=obstime)) # HCI (Heliocentric Inertial)
     hee = gcrs.transform_to(HeliocentricEarthEcliptic(obstime=obstime)) # (Heliocentric Earth Ecliptic)
     hae = gcrs.transform_to(HeliocentricMeanEcliptic(obstime=obstime)) # HAE (Heliocentric Aries Ecliptic)
@@ -518,6 +526,9 @@ def organize_spacecraft_position_keywords(observation_time, before_xact_db, befo
         "HCIX_OBS": hci.cartesian.x.to(u.m).value,
         "HCIY_OBS": hci.cartesian.y.to(u.m).value,
         "HCIZ_OBS": hci.cartesian.z.to(u.m).value,
+        "HCIX_VOB": hci.cartesian.differentials['s'].d_x.to(u.m/u.s).value,
+        "HCIY_VOB": hci.cartesian.differentials['s'].d_y.to(u.m/u.s).value,
+        "HCIY_VOB": hci.cartesian.differentials['s'].d_z.to(u.m/u.s).value,
         "HEEX_OBS": hee.cartesian.x.to(u.m).value,
         "HEEY_OBS": hee.cartesian.y.to(u.m).value,
         "HEEZ_OBS": hee.cartesian.z.to(u.m).value,

--- a/punchbowl/level1/alignment.py
+++ b/punchbowl/level1/alignment.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import scipy
 import sep
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import GCRS, CartesianDifferential, CartesianRepresentation, SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS, DistortionLookupTable, NoConvergence, utils
 from ndcube import NDCube
@@ -19,6 +19,7 @@ from prefect import get_run_logger
 from regularizepsf import ArrayPSFTransform
 from scipy.spatial import KDTree
 from skimage.transform import resize
+from sunpy.coordinates import HeliocentricInertial
 
 from punchbowl.data import NormalizedMetadata
 from punchbowl.data.wcs import calculate_celestial_wcs_from_helio, calculate_helio_wcs_from_celestial
@@ -518,17 +519,26 @@ def prep_star_coords(stars_in_image: pd.DataFrame, image_header: NormalizedMetad
     assumed to be ICRS. But as long as it's a consistent set of RA-Dec values, it doesn't matter what frame the
     coordinates think they're in.
     """
+    position = CartesianRepresentation(image_header["HCIX_OBS"] * u.m,
+                                       image_header["HCIY_OBS"] * u.m,
+                                       image_header["HCIZ_OBS"] * u.m)
+    velocity = CartesianDifferential(image_header["HCIX_VOB"] * u.m / u.s,
+                                     image_header["HCIY_VOB"] * u.m / u.s,
+                                     image_header["HCIZ_VOB"] * u.m / u.s)
+    sc = HeliocentricInertial(position.with_differentials(velocity))
+    sc_gcrs = sc.transform_to(GCRS(obstime=image_header.astropy_time))
+
     # Convert stellar coordinates to GCRS centered on the spacecraft location
-    sc_location = EarthLocation.from_geodetic(lon=image_header["GEOD_LON"].value * u.deg,
-                                              lat=image_header["GEOD_LAT"].value * u.deg,
-                                              height=image_header["GEOD_ALT"].value * u.m)
-    geoloc, geovel = sc_location.get_gcrs_posvel(image_header.astropy_time)
     catalog_stars = SkyCoord(
         np.array(stars_in_image["RAdeg"]) * u.degree,
         np.array(stars_in_image["DEdeg"]) * u.degree,
         np.array(stars_in_image["Dist_ly"]) * u.lyr,
-        frame="icrs", obsgeoloc=geoloc, obsgeovel=geovel, obstime=image_header.astropy_time,
-    ).transform_to("gcrs")
+        frame="icrs",
+    ).transform_to(GCRS(obsgeoloc=sc_gcrs.cartesian,
+                        obsgeovel=sc_gcrs.cartesian.differentials["s"].d_xyz,
+                        obstime=image_header.astropy_time))
+
+    # Re-label them as ICRS so the image WCS can handle them
     return SkyCoord(catalog_stars.ra, catalog_stars.dec, frame="icrs")
 
 


### PR DESCRIPTION
This PR writes s/c velocities in the L0 headers.

Also, previously we were confusing ITRS and GCRS. The former rotates with the Earth; the latter is fixed to the stars. This fixes and simplifies the conversions. Here's the test for the positions:

https://github.com/user-attachments/assets/c0a559bc-976c-4a0e-95c0-780bc54c7ff0

The old coordinates mixed in Earth's rotation, while the new keeps us on the terminator.

The HCI velocities written by this PR agree closely with finite-differencing the HCI positions, so that conversion seems correct.