### PR TITLE
Remove unused DB column

### DIFF
--- a/changelog/956.misc.rst
+++ b/changelog/956.misc.rst
@@ -1,1 +1,0 @@
-Remove unused "Priority" column from sci_xfi database table.

--- a/changelog/956.misc.rst
+++ b/changelog/956.misc.rst
@@ -1,0 +1,1 @@
+Remove unused "Priority" column from sci_xfi database table.

--- a/changelog/956.trivial.rst
+++ b/changelog/956.trivial.rst
@@ -1,0 +1,1 @@
+Remove unused "Priority" column from sci_xfi database table.

--- a/punchbowl/auto/control/db.py
+++ b/punchbowl/auto/control/db.py
@@ -157,7 +157,6 @@ class SCI_XFI(Base):
     compression_settings = Column(Integer, nullable=False)
     acquisition_settings = Column(Integer, nullable=False)
     packet_group = Column(Integer, nullable=False)
-    priority = Column(Integer, nullable=False, default=0)
 
 Index("unused_packet_query", SCI_XFI.spacecraft_id, SCI_XFI.is_used)
 


### PR DESCRIPTION
We briefly used a Priority column to influence image formation attempts, before switching to a least-recently-retried system. We can get rid of the column definition, and then remove it from the production DB as well.

(190 didn't have the column in the DB, so TLM ingest was failing.)