### PR TITLE
Cap load_many_cubes n_workers at number of files

### DIFF
--- a/changelog/965.feature.rst
+++ b/changelog/965.feature.rst
@@ -1,0 +1,1 @@
+`load_many_cubes` caps the number of workers at the number of files.

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -485,7 +485,9 @@ def load_many_cubes_iterable(paths: list[str | Path], n_workers: int | None = No
 
     """
     context = mp.get_context("forkserver")
-    with ProcessPoolExecutor(n_workers, mp_context=context) as p:
+    if n_workers is None or n_workers < 0:
+        n_workers = os.cpu_count()
+    with ProcessPoolExecutor(min(n_workers, len(paths)), mp_context=context) as p:
         yield from p.map(_load_many_cubes_caller, paths, repeat(kwargs), repeat(allow_errors))
 
 


### PR DESCRIPTION
This is probably most useful on 190, where a default 128 workers doesn't make sense for 20 files.