### PR TITLE
Add threadpool_limits helper function

### DIFF
--- a/changelog/970.feature.rst
+++ b/changelog/970.feature.rst
@@ -1,0 +1,1 @@
+Add threadpool_limits helper function.

--- a/punchbowl/level1/despike.py
+++ b/punchbowl/level1/despike.py
@@ -3,13 +3,13 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 from prefect import get_run_logger
 from scipy.ndimage import binary_dilation, gaussian_filter
-from threadpoolctl import threadpool_limits
 
 from punchbowl.data import load_ndcube_from_fits
 from punchbowl.data.punchcube import PUNCHCube
 from punchbowl.level1.deficient_pixel import mean_correct
 from punchbowl.level1.sqrt import decode_sqrt_data
 from punchbowl.prefect import punch_task
+from punchbowl.util import limit_threads
 
 
 def despike_polseq(
@@ -143,7 +143,7 @@ def despike_polseq_task(data_object: PUNCHCube,
         neighbors = [load_ndcube_from_fits(n) if isinstance(n, str) else n for n in neighbors]
         neighbors = [decode_sqrt_data(n) for n in neighbors]
 
-        with threadpool_limits(max_workers):
+        with limit_threads(max_workers):
             data_object, spikes = despike_polseq(
                                             data_object,
                                             neighbors,

--- a/punchbowl/level1/destreak.py
+++ b/punchbowl/level1/destreak.py
@@ -1,9 +1,8 @@
 import numpy as np
-from threadpoolctl import threadpool_limits
 
 from punchbowl.data.punchcube import PUNCHCube
 from punchbowl.prefect import punch_task
-from punchbowl.util import validate_image_is_square
+from punchbowl.util import limit_threads, validate_image_is_square
 
 
 def streak_correction_matrix(
@@ -105,7 +104,7 @@ def correct_streaks(
 
     """
     validate_image_is_square(image)
-    with threadpool_limits(max_workers):
+    with limit_threads(max_workers):
         correction_matrix = streak_correction_matrix(image.shape[0], exposure_time, readout_line_time, reset_line_time)
         return correction_matrix.T @ image
 

--- a/punchbowl/level3/f_corona_model.py
+++ b/punchbowl/level3/f_corona_model.py
@@ -14,7 +14,6 @@ from numpy.polynomial import polynomial
 from prefect import get_run_logger
 from quadprog import solve_qp
 from scipy.interpolate import griddata
-from threadpoolctl import threadpool_limits
 
 from punchbowl.data import NormalizedMetadata
 from punchbowl.data.punch_io import load_ndcube_from_fits
@@ -22,7 +21,7 @@ from punchbowl.data.punchcube import PUNCHCube
 from punchbowl.data.wcs import load_trefoil_wcs
 from punchbowl.exceptions import InvalidDataError
 from punchbowl.prefect import punch_flow, punch_task
-from punchbowl.util import ShmPickleableNDArray, average_datetime, interpolate_data, nan_percentile
+from punchbowl.util import ShmPickleableNDArray, average_datetime, interpolate_data, limit_threads, nan_percentile
 
 
 def solve_qp_cube(input_vals: np.ndarray, cube: np.ndarray,
@@ -134,7 +133,7 @@ def model_fcorona_for_cube_real(xt: np.ndarray,
 
 
     # Since we're parallelizing with processes, we shouldn't run a lot of threads
-    with threadpool_limits(2), mp.Pool(processes=num_workers) as pool:
+    with limit_threads(2), mp.Pool(processes=num_workers) as pool:
         chunks = pool.starmap(_model_fcorona_for_cube_inner, args(), chunksize=4)
 
     # Combine the outputs of each task into final output arrays

--- a/punchbowl/levelq/pca.py
+++ b/punchbowl/levelq/pca.py
@@ -13,12 +13,11 @@ from astropy.time import Time
 from astropy.wcs import WCS
 from prefect import get_run_logger
 from sklearn.decomposition import PCA
-from threadpoolctl import threadpool_limits
 
 from punchbowl.data import NormalizedMetadata
 from punchbowl.data.punchcube import PUNCHCube
 from punchbowl.prefect import punch_task
-from punchbowl.util import DataLoader, load_image_task
+from punchbowl.util import DataLoader, limit_threads, load_image_task
 
 
 @punch_task
@@ -30,7 +29,7 @@ def pca_filter(input_cubes: list[PUNCHCube], files_to_fit: list[PUNCHCube | Data
     all_files_to_fit, bodies_in_quarter, to_subtract, good_data_mask, is_outlier = load_files(
         input_cubes, files_to_fit, blend_size)
     # 25 threads per worker would saturate all our cores if they all run at once, but experience shows they don't.
-    with threadpool_limits(min(25, os.cpu_count())), ThreadPoolExecutor(min(n_strides, os.cpu_count())) as p:
+    with limit_threads(min(25, os.cpu_count())), ThreadPoolExecutor(min(n_strides, os.cpu_count())) as p:
         for subtracted_cube_indices, subtracted_images in p.map(
                 pca_filter_one_stride, repeat(all_files_to_fit), range(n_strides), repeat(n_strides),
                 repeat(bodies_in_quarter), repeat(to_subtract), repeat(n_components), repeat(med_filt),

--- a/punchbowl/util.py
+++ b/punchbowl/util.py
@@ -5,10 +5,12 @@ import threading
 from typing import Any, Self, Generic, TypeVar
 from datetime import UTC, datetime
 from functools import cached_property
+from contextlib import contextmanager
 from multiprocessing.shared_memory import SharedMemory
 
 import numba
 import numpy as np
+import threadpoolctl
 from astropy.wcs import WCS
 from dateutil.parser import parse as parse_datetime
 from numpy.typing import ArrayLike
@@ -636,3 +638,25 @@ class ShmPickleableNDArray(np.ndarray):
 
         return ShmPickleableNDArray.__new__, (ShmPickleableNDArray, self.shape, self.dtype, self.shm.name,
                                               self.strides, offset, True)
+
+
+@contextmanager
+def limit_threads(n_threads: int | None) -> None:
+    """
+    Limit thread counts only if called for.
+
+    Applies thread count limits only if they're provided (not None) and if they're more restrictive than the
+    currently-set limits.
+
+    I've found that calling threadpool_limits after forking can cause segfaults. The thing to do is to call it before
+    forking and not after, and the limits applied pre-fork apply to each worker individually. By running all our
+    threadpool_limits calls through this helper, it's possible to run unmodified punchbowl code post-fork and prevent
+    threadpool_limits calls, by passing `None` for max_workers or similar arguments.
+    """
+    if n_threads is None:
+        # Do nothing, as a context manager.
+        yield
+        return
+
+    with threadpoolctl.threadpool_limits(n_threads):
+        yield


### PR DESCRIPTION
A long-running annoyance for me is that calling threadpool_limits after forking can cause segfaults. The thing to do is to call it before forking and not after, and the limits applied pre-fork apply to each worker individually. By running all our threadpool_limits calls through this helper, it's possible to run unmodified punchbowl code post-fork and prevent threadpool_limits calls by passing `max_workers=None`.

The `threadpool_limits` docs say it does nothing if you pass in `None`, but looking at the source code, they set not limits on entry, but they still reset the limits on exit, so passing `None` to `threadpool_limits` still causes the segfaults.