### PR TITLE
Daily quicklook scheduling

### DIFF
--- a/changelog/978.bugfix.rst
+++ b/changelog/978.bugfix.rst
@@ -1,0 +1,1 @@
+Updates daily movie quicklook scheduling to include files created in the past 24 hours, not by the date of observation.

--- a/punchbowl/auto/flows/visualize.py
+++ b/punchbowl/auto/flows/visualize.py
@@ -26,8 +26,8 @@ def visualize_query_ready_files(session, pipeline_config: dict, reference_time: 
         for product_code in product_codes:
             product_ready_files = (session.query(File)
                                     .filter(File.state.in_(["created", "progressed", "quickpunched"]))
-                                    .filter(File.date_obs >= (reference_time - timedelta(hours=lookback_hours)))
-                                    .filter(File.date_obs <= reference_time)
+                                    .filter(File.date_created >= (reference_time - timedelta(hours=lookback_hours)))
+                                    .filter(File.date_created <= reference_time)
                                     .filter(File.level == level)
                                     .filter(File.file_type == product_code[0:2])
                                     .filter(File.observatory == product_code[2])

--- a/punchbowl/auto/flows/visualize.py
+++ b/punchbowl/auto/flows/visualize.py
@@ -4,6 +4,7 @@ import tempfile
 from datetime import UTC, datetime, timedelta
 
 from prefect import flow, get_run_logger, task
+from prefect.cache_policies import NO_CACHE
 from prefect.context import get_run_context
 from prefect.runtime import flow_run
 
@@ -14,7 +15,7 @@ from punchbowl.data.meta import construct_all_product_codes
 from punchbowl.data.punch_io import load_ndcube_from_fits, write_ndcube_to_quicklook, write_quicklook_to_mp4
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def visualize_query_ready_files(session, pipeline_config: dict, reference_time: datetime, lookback_hours: float = 24):
     logger = get_run_logger()
 
@@ -40,7 +41,7 @@ def visualize_query_ready_files(session, pipeline_config: dict, reference_time: 
     return all_ready_files, all_product_codes
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def visualize_flow_info(input_files: list[File],
                         product_code: str,
                         pipeline_config: dict,

--- a/punchbowl/auto/flows/visualize.py
+++ b/punchbowl/auto/flows/visualize.py
@@ -3,8 +3,8 @@ import json
 import tempfile
 from datetime import UTC, datetime, timedelta
 
-from prefect.cache_policies import NO_CACHE
 from prefect import flow, task
+from prefect.cache_policies import NO_CACHE
 from prefect.context import get_run_context
 from prefect.runtime import flow_run
 


### PR DESCRIPTION
Updates daily movie quicklook scheduling to include files created in the past 24 hours, not by the date of observations. This was leading to movies not being generated, presumably from processing delays.