### PR TITLE
Remove space in WFI3 plotting keywords preventing it from plotting

### DIFF
--- a/changelog/979.bugfix.rst
+++ b/changelog/979.bugfix.rst
@@ -1,0 +1,1 @@
+Removes unintended space that prevented labeling WFI-3 in `plot_punch`.

--- a/punchbowl/data/visualize.py
+++ b/punchbowl/data/visualize.py
@@ -345,8 +345,8 @@ def plot_punch(  # noqa: C901
     if label_satellites:
         position_keywords = ["CTRXWFI1", "CTRYWFI1",
                              "CTRXWFI2", "CTRYWFI2",
-                             "CTRXWFI3"," CTRYWFI3",
-                             "CTRXNFI4","CTRYNFI4"]
+                             "CTRXWFI3", "CTRYWFI3",
+                             "CTRXNFI4", "CTRYNFI4"]
         for i in range(0, 8, 2):
             satellite = position_keywords[i][-4:]
             if position_keywords[i] in cube.meta and position_keywords[i+1] in cube.meta:


### PR DESCRIPTION
There was a bug in the WFI3 label that included a space. It then didn't find the keyword in the metadata and thus didn't plot the label as requested.