### PR TITLE
Misc change rollup from v0l tests

### DIFF
--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -1208,12 +1208,6 @@ def level0_form_images(pipeline_config, defs, apid_name2num, outlier_limits, mas
 
     image_inputs.sort()
 
-    last_attempts = [e[0][1] for e in image_inputs if e[0][0]]
-    retry_timestamps = [e[1][1] for e in image_inputs if e[0][0]]
-    new_timestamps = [e[1][1] for e in image_inputs if not e[0][0]]
-
-    # Remove the sort key
-    image_inputs = [e[1] for e in image_inputs]
     max_images_per_flow = pipeline_config["flows"]["level0"]["options"].get("max_images_per_flow", 2_000)
     unique_image_inputs = []
     seen_inputs = set()
@@ -1223,6 +1217,14 @@ def level0_form_images(pipeline_config, defs, apid_name2num, outlier_limits, mas
             unique_image_inputs.append(image_input)
             if len(unique_image_inputs) >= max_images_per_flow:
                 break
+
+    last_attempts = [e[0][1] for e in unique_image_inputs if e[0][0]]
+    retry_timestamps = [e[1][1] for e in unique_image_inputs if e[0][0]]
+    new_timestamps = [e[1][1] for e in unique_image_inputs if not e[0][0]]
+
+    # Remove the sort key
+    unique_image_inputs = [e[1] for e in unique_image_inputs]
+
     # Attach everything we need as inputs
     image_inputs = [(*image_input, defs, apid_name2num, pipeline_config, spacecraft_secrets,
                              outlier_limits, masks, processing_flow_id) for image_input in unique_image_inputs]

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -683,10 +683,9 @@ def get_metadata(first_image_packet,
     dt = func.abs(func.timestampdiff(text("second"), ENG_XACT.timestamp, observation_midpoint))
     middle_xact_db = (session.query(ENG_XACT)
                   .filter(ENG_XACT.spacecraft_id == spacecraft_id)
-                  .filter(ENG_XACT.timestamp >= observation_time)
-                  .filter(ENG_XACT.timestamp <= observation_end)
+                  .filter(ENG_XACT.timestamp >= observation_time - packet_window_size)
+                  .filter(ENG_XACT.timestamp <= observation_end + packet_window_size)
                   .order_by(dt.asc()).first())
-
 
     # get the PFW packet right before the observation
     best_pfw_db = (session.query(ENG_PFW)

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -1208,6 +1208,11 @@ def level0_form_images(pipeline_config, defs, apid_name2num, outlier_limits, mas
     logger.info(f"Got {len(image_inputs)} images to try forming")
 
     image_inputs.sort()
+
+    last_attempts = [e[0][1] for e in image_inputs if e[0][0]]
+    retry_timestamps = [e[1][1] for e in image_inputs if e[0][0]]
+    new_timestamps = [e[1][1] for e in image_inputs if not e[0][0]]
+
     # Remove the sort key
     image_inputs = [e[1] for e in image_inputs]
     max_images_per_flow = pipeline_config["flows"]["level0"]["options"].get("max_images_per_flow", 2_000)
@@ -1223,9 +1228,6 @@ def level0_form_images(pipeline_config, defs, apid_name2num, outlier_limits, mas
     image_inputs = [(*image_input, defs, apid_name2num, pipeline_config, spacecraft_secrets,
                              outlier_limits, masks, processing_flow_id) for image_input in unique_image_inputs]
 
-    last_attempts = [e[0][1] for e in image_inputs if e[0][0]]
-    retry_timestamps = [e[1][1] for e in image_inputs if e[0][0]]
-    new_timestamps = [e[1][1] for e in image_inputs if not e[0][0]]
     logger.info(f"Will run {len(image_inputs)} attempts, including {len(retry_timestamps)} retries")
     if retry_timestamps:
         logger.info(f"Retries were last attempted between {min(last_attempts)} and {max(last_attempts)}")

--- a/punchbowl/level1/psf.py
+++ b/punchbowl/level1/psf.py
@@ -139,7 +139,8 @@ def correct_psf(
     new_data = psf_transform.apply(data.data, workers=max_workers,
                                    saturation_threshold=saturation_threshold,
                                    saturation_dilation=saturation_dilation,
-                                   neighborhood_width=neighborhood_width)
+                                   neighborhood_width=neighborhood_width,
+                                   normalization_coefficient=(8/9)**2)
 
     data.data[...] = new_data[...]
 

--- a/punchbowl/level3/flow.py
+++ b/punchbowl/level3/flow.py
@@ -120,7 +120,7 @@ def level3_core_flow(data_list: list[str] | list[PUNCHCube],
     for o in data_list:
         out_meta: NormalizedMetadata = NormalizedMetadata.load_template("PTM" if is_polarized else "CTM", "3")
         out_meta["DATE"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
-        out_meta.provenance = [fname for d in data_list if d is not None and (fname := d.meta.get("FILENAME").value)]
+        out_meta.provenance = [fname for d in data_list if d is not None and (fname := d.meta.get("FILENAME"))]
         out_meta.history = o.meta.history
         out_meta["CALSTAR1"] = before_starfield_path
         out_meta["CALSTAR2"] = after_starfield_path

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -23,11 +23,7 @@ from solpolpy.util import solnorth_from_wcs
 
 from punchbowl.data import NormalizedMetadata, load_ndcube_from_fits, write_ndcube_to_fits
 from punchbowl.data.punchcube import PUNCHCube
-from punchbowl.data.wcs import (
-    calculate_celestial_wcs_from_helio,
-    calculate_helio_wcs_from_celestial,
-    celestial_north_from_wcs,
-)
+from punchbowl.data.wcs import calculate_helio_wcs_from_celestial, celestial_north_from_wcs
 from punchbowl.exceptions import InvalidDataError
 from punchbowl.prefect import punch_flow, punch_task
 from punchbowl.util import average_datetime, interpolate_data
@@ -361,10 +357,10 @@ def subtract_starfield_background_task(data_object: PUNCHCube,
         shape_before = star_datacube_before.data.shape[-2:]
         shape_after = star_datacube_after.data.shape[-2:]
 
-        wcs_celestial_before = calculate_celestial_wcs_from_helio(star_datacube_before.wcs)
+        wcs_celestial_before = star_datacube_before.celestial_wcs
         wcs_celestial_before.wcs.cdelt[0] = wcs_celestial_before.wcs.cdelt[0] * -1
 
-        wcs_celestial_after = calculate_celestial_wcs_from_helio(star_datacube_after.wcs)
+        wcs_celestial_after = star_datacube_after.celestial_wcs
         wcs_celestial_after.wcs.cdelt[0] = wcs_celestial_after.wcs.cdelt[0] * -1
 
         # TODO - Test with polarized data...
@@ -416,7 +412,7 @@ def subtract_starfield_background_task(data_object: PUNCHCube,
                                         wcs_celestial[0])
             subtracted = starfield_model.subtract_from_image(
                 PUNCHCube(data=np.stack((data_object.data, data_object.uncertainty.array), axis=0),
-                       wcs=data_object.wcs.celestial,
+                       wcs=data_object.wcs.celestial_wcs,
                        meta=data_object.meta),
                 handle_wrap_point=False,
                 processor=PUNCHImageProcessor(key="A"))
@@ -428,7 +424,7 @@ def subtract_starfield_background_task(data_object: PUNCHCube,
             starfield_model = Starfield(np.stack((star_datacube.data, star_datacube.uncertainty.array)), wcs_celestial)
             subtracted = starfield_model.subtract_from_image(
                 PUNCHCube(data=np.stack((data_object.data, data_object.uncertainty.array)),
-                       wcs=data_object.wcs,
+                       wcs=data_object.celestial_wcs,
                        meta=data_object.meta),
                 handle_wrap_point=False,
                 processor=PUNCHImageProcessor(key="A"))

--- a/scripts/auto/rewrite-outlier-flags.py
+++ b/scripts/auto/rewrite-outlier-flags.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import hashlib
+import multiprocessing
+from glob import glob
+from datetime import UTC, datetime
+
+from astropy.io import fits
+from dateutil.parser import parse as parse_datetime_str
+from prefect_sqlalchemy import SqlAlchemyConnector
+from sqlalchemy.orm import Session
+from tqdm import tqdm
+
+from punchbowl.auto.control.db import File
+from punchbowl.limits import LimitSet
+
+n_procs = int(sys.argv[-1])
+
+base_dir = '/d0/soc/data/'
+
+limits_path = '/home/samuel.vankooten/outlier_limits/v0l'
+limit_files = glob(os.path.join(limits_path, '*.npz'))
+
+outlier_limits = []
+if limit_files is not None:
+    for limit_file in limit_files:
+        limits = LimitSet.from_file(limit_file)
+        file_name = os.path.basename(limit_file)
+        code = file_name.split("_")[2][1]
+        obs = file_name.split("_")[2][2]
+        version = file_name.split("_")[-1].split('.')[0]
+        date = datetime.strptime(file_name.split('_')[3], '%Y%m%d%H%M%S')
+        outlier_limits.append((obs, code, date, file_name, limits, version))
+
+outlier_limits.sort(key=lambda x: (x[-1], x[2]), reverse=True)
+
+print(f"Loaded {len(outlier_limits)} limit files")
+
+credentials = SqlAlchemyConnector.load("mariadb-creds", _sync=True)
+engine = credentials.get_engine()
+session = Session(engine)
+
+target_files = (session.query(File).where(File.level == '0')
+                .where(File.observatory != '4').all())
+target_paths = [os.path.join(f.directory('/d0/punchsoc/real_data/'), f.filename()) for f in target_files]
+
+print(f"Identified {len(target_files)} files to re-write")
+
+def write_file_hash(path: str) -> None:
+    """Create a SHA-256 hash for a file."""
+    file_hash = hashlib.sha256()
+    with open(path, "rb") as f:
+        fb = f.read()
+        file_hash.update(fb)
+
+    with open(path + ".sha", "w") as f:
+        f.write(file_hash.hexdigest())
+
+def rewrite_file(path):
+    try:
+        with fits.open(path, lazy_load_hdus=False, disable_image_compression=True, mode='update') as hdul:
+            header = hdul[1].header
+            selected_limits = None
+            for limit_observatory, limit_type, limit_date, limit_filename, limits, version in outlier_limits:
+                if limit_observatory != header['OBSCODE']:
+                    continue
+                if limit_type != header['TYPECODE'][1]:
+                    continue
+                if limit_date > parse_datetime_str(header['DATE-OBS']):
+                    continue
+                selected_limits = limits
+                header['HISTORY'] = (f"{datetime.now(UTC):%Y-%m-%dT%H:%M:%S} => rewrite-outlier-flags => Outlier "
+                                     f"detection re-done with {limit_filename}|")
+                break
+            if selected_limits is None:
+                raise RuntimeError(f"Could not find outlier limits for {path}")
+            else:
+                is_outlier = not selected_limits.is_good(header)
+
+            is_outlier = is_outlier or header['BADPKTS']
+
+            header['OUTLIER'] = int(is_outlier)
+            now = datetime.now(UTC)
+            header['DATE'] = now.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3]
+
+            hdul.flush()
+        write_file_hash(path)
+        return is_outlier
+    except:
+        print(f"Error loading {path}")
+        raise
+
+with multiprocessing.Pool(n_procs) as p, tqdm(total=len(target_files)) as pbar:
+    for i, (f, new_outlier_status) in enumerate(zip(target_files, p.imap(rewrite_file, target_paths, chunksize=5))):
+        f.outlier = new_outlier_status
+        pbar.update(1)
+        if i % 4000 == 0:
+            session.commit()
+session.commit()


### PR DESCRIPTION
Collecting the small miscellaneous changes so far (including some that I assume @jmbhughes made last week), including:

* Some images didn't have any XACT packets during the exposure, so use a search range as wide as we use for the "closest before" packet
* Fix for logging L0 retry vs. new-attempt counts and time ranges
* Add the PSF normalization factor we need now
* Add the script I used to re-do the outlier flags in L0 images. (I'd written out the new limits incorrectly)