### PR TITLE
Pin fastapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "punchbowl"
 dynamic = ["version"]
 dependencies = [
+    "fastapi==0.136.0",
     "numpy",
     "astropy",
     "sunpy[all]",


### PR DESCRIPTION
Our CI started failing because it was using fastapi==0.137.0 which wasn't playing nice with Prefect. We're waiting on a new Prefect release including https://github.com/PrefectHQ/prefect/issues/22276 to fix this. Until then, I've pinned fastapi. 