### PR TITLE
Fix binder build

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -25,10 +25,6 @@ jobs:
         # Target architecture of the ffmpeg executable to install. Defaults to the
         # system architecture. Only x64 and arm64 are supported (arm64 only on Linux).
         architecture: ''
-        # Linking type of the binaries. Use "shared" to download shared binaries and
-        # "static" for statically linked ones. Shared builds are currently only available
-        # for windows releases. Defaults to "static"
-        linking-type: static
         # As of version 3 of this action, builds are no longer downloaded from GitHub
         # except on Windows: https://github.com/GyanD/codexffmpeg/releases.
         github-token: ${{ github.server_url == 'https://github.com' && github.token || '' }}


### PR DESCRIPTION
The CI was complaining about unknown input of "linking-type" for ffmpeg so I removed it. See https://github.com/punch-mission/punchbowl/actions/runs/27631825800 for reference