### PR TITLE
Remove pytest.ini

### DIFF
--- a/changelog/993.feature.rst
+++ b/changelog/993.feature.rst
@@ -1,0 +1,1 @@
+Merges contents of pytest.ini into pyproject.toml for clarity. Adds a minimum version number for the reproject package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy",
     "lmfit",
     "setuptools",
-    "reproject",
+    "reproject>=0.20.0",
     "pylibjpeg",
     "python-dateutil",
     "remove_starfield>=0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ no_lines_before = "LOCALFOLDER"
 sections = "FUTURE, COMPATIBILITY, STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER"
 
 [tool.pytest.ini_options]
+addopts = "--mpl"
 markers = [
     "prefect_test: a test that integrates with Prefect",
     "regression: a regression test, likely slow",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --mpl


### PR DESCRIPTION
## PR summary

Merges contents of pytest.ini into pyproject.toml.

Adds minimum required version for reproject.

## Todos

None

## Test plan

Tests pass on my local machine

## Breaking changes

None known

## Related Issues

None known