### PR TITLE
Log progress messages when building starfields

### DIFF
--- a/changelog/1028.feature.rst
+++ b/changelog/1028.feature.rst
@@ -1,0 +1,1 @@
+Starfield model generation now logs progress messages in Prefect.

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -216,6 +216,42 @@ def determine_wcs(filenames: list, map_scale: float) -> WCS:
     return starfield_wcs[ymin:ymax, xmin:xmax]
 
 
+class LoggingProgressIndicator:
+    """Class implementing remove_starfield's interface for progress indications, which sends progress to the logger."""
+
+    def __init__(self, n_units: int, description: str) -> None:
+        """
+        Initialize the indicator.
+
+        Parameters
+        ----------
+        n_units : int
+            How high the "progress bar" should count to.
+        description : str
+            The descriptive name for the progress bar.
+
+        """
+        self.logger = get_logger()
+        self.description = description
+        self.n_units = n_units
+        self.count = 0
+
+    def update(self) -> None:
+        """Increment the progress bar."""
+        self.count += 1
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Display the progress bar."""
+        frequency = 25 if self.description == "Reprojecting" else 250
+        if self.count % frequency == 0:
+            self.logger.info(f"{self.description} progress: {self.count} / {self.n_units}")
+
+    def close(self) -> None:
+        """Finish the progress bar."""
+        self.logger.info(f"{self.description} complete")
+
+
 @punch_flow(log_prints=True, timeout_seconds=21_600)
 def generate_starfield_background(
         filenames: list[str],
@@ -267,6 +303,7 @@ def generate_starfield_background(
             handle_wrap_point=False,
             dtype=np.float32,
             mask_strategy=BlockMasker(128, 128),
+            pbar_class=LoggingProgressIndicator,
             target_mem_usage=target_mem_usage)
         logger.info("Done building starfields")
 
@@ -291,6 +328,7 @@ def generate_starfield_background(
             handle_wrap_point=False,
             dtype=np.float32,
             mask_strategy=BlockMasker(128, 128),
+            pbar_class=LoggingProgressIndicator,
             target_mem_usage=target_mem_usage)
         logger.info("Ending clear starfield")
         out_data = starfield_clear.starfield - percentile_filter(starfield_clear.starfield, 5, 10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ super_user = [
     "pre-commit",
     "prefect[dask]",
     "pylibjpeg[libjpeg,openjpeg]",
-    "remove_starfield>=0.1",
+    "remove_starfield>=0.1.1",
     "reproject>=0.20.0",
     "scikit-image",
     "scikit-learn",

--- a/uv.lock
+++ b/uv.lock
@@ -4860,7 +4860,7 @@ requires-dist = [
     { name = "pylibjpeg", extras = ["libjpeg", "openjpeg"], marker = "extra == 'super-user'" },
     { name = "python-dateutil" },
     { name = "regularizepsf" },
-    { name = "remove-starfield", marker = "extra == 'super-user'", specifier = ">=0.1" },
+    { name = "remove-starfield", marker = "extra == 'super-user'", specifier = ">=0.1.1" },
     { name = "reproject", marker = "extra == 'super-user'", specifier = ">=0.20.0" },
     { name = "requests" },
     { name = "scikit-image", marker = "extra == 'super-user'" },


### PR DESCRIPTION
With a new change in `remove_starfield`, we can now get progress messages in prefect during the 1+ hour starfield generation process.

This requires `remove_starfield >= 0.1.1`---I'll wait until #922 is merged before making that change.

<img width="964" height="1093" alt="image" src="https://github.com/user-attachments/assets/801921f1-ef0f-4e43-8274-181ebd816a2d" />
