### PR TITLE
1031 unit test coverage

### DIFF
--- a/changelog/1031.trivial.rst
+++ b/changelog/1031.trivial.rst
@@ -1,0 +1,1 @@
+Introduce rules to omit test scripts themselves from test coverage metrics.

--- a/punchbowl/level1/tests/test_despike.py
+++ b/punchbowl/level1/tests/test_despike.py
@@ -9,7 +9,7 @@ from astropy.wcs.utils import add_stokes_axis_to_wcs
 
 from punchbowl.data.meta import NormalizedMetadata
 from punchbowl.data.punchcube import PUNCHCube
-from punchbowl.level1.despike import despike_polseq
+from punchbowl.level1.despike import despike_polseq, despike_polseq_task
 
 
 @pytest.fixture
@@ -52,7 +52,6 @@ def test_spikes_are_removed(num_neighbors, sample_ndcube_for_despike):
 
     despiked, spike_map = despike_polseq(sample_data, sample_neighbors)
 
-    print("MAX", np.max(despiked.data))
     assert np.all(despiked.data <= 10)
     assert spike_map[-1][30, 20] == 1
 
@@ -69,3 +68,27 @@ def test_insufficient_spike_neighbors(num_neighbors, sample_ndcube_for_despike):
 
     with pytest.raises(RuntimeError):
         _, _ = despike_polseq(sample_data, sample_neighbors)
+
+def test_despike_polseq_task(sample_ndcube_for_despike):
+    reference = np.random.random((300, 300))
+    reference[30, 20] = 10
+
+    neighbors = [np.random.random((300, 300)) for _ in range(6)]
+    sample_data = sample_ndcube_for_despike(reference, code="PP3", level="0")
+    sample_neighbors = [sample_ndcube_for_despike(n, code="PP3", level="0") for n in neighbors]
+
+    despiked_data = despike_polseq_task.fn(sample_data, sample_neighbors)
+    assert(isinstance(despiked_data, PUNCHCube))
+    assert(despiked_data.meta.history.most_recent().comment=="neighbor_count=6")
+    assert(np.all(despiked_data.data <= 10))
+
+    #need to remake sample_data because it is altered above
+    reference = np.random.random((300, 300))
+    reference[30, 20] = 10
+    sample_data = sample_ndcube_for_despike(reference, code="PP3", level="0")
+
+    undespiked_data = despike_polseq_task.fn(sample_data, [sample_neighbors[0]])
+    assert(isinstance(undespiked_data, PUNCHCube))
+    assert(undespiked_data.meta.history.most_recent().comment=="Incompatible neighbor count so no correction applied")
+    assert(sample_data.data[30,20]==10)
+    assert(undespiked_data.data[30,20]==10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,9 @@ skip = "*.fts,*.fits,venv,*.pro,*.asdf,*.ipynb"
 [tool.coverage.run]
 omit = [
     "tests/*",
-    "**/test_*.py"
+    "**/tests/*",
+    "**/test_*.py",
+    "**/*test.py",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,12 @@ packages = ["punchbowl"]
 [tool.codespell]
 skip = "*.fts,*.fits,venv,*.pro,*.asdf,*.ipynb"
 
+[tool.coverage.run]
+omit = [
+    "tests/*",
+    "**/test_*.py"
+]
+
 [tool.ruff]
 target-version = 'py311'
 exclude = ['tests', 'scripts', 'docs', 'examples', "punchbowl/auto/*"]


### PR DESCRIPTION
## PR summary

This PR adds a section to pyproject.toml so that test scripts are not counted in the overall test coverage metrics. As a result merging this PR is expected to *decrease* the punchbowl test coverage from ~58% to ~44%.

This also increases the test coverage of the level1/despiking code to 100%.

## Todos

None

## Test plan

N/A

## Breaking changes

N/A

## Related Issues

Closes #1031 