### PR TITLE
Coalign MZP before polarization resolution

### DIFF
--- a/changelog/1060.feature.rst
+++ b/changelog/1060.feature.rst
@@ -1,0 +1,2 @@
+In L2 mosaic assembly, polarized inputs are now co-aligned before the polarization is converted to solar MZP, to
+account for small pointing drift through the imaging sequence.

--- a/changelog/1060.feature.rst
+++ b/changelog/1060.feature.rst
@@ -1,2 +1,2 @@
-In L2 mosaic assembly, polarized inputs are now co-aligned before the polarization is converted to solar MZP, to
+In L2 mosaic assembly, polarized inputs are now co-aligned before the polarization is converted to MZP_solar, to
 account for small pointing drift through the imaging sequence.

--- a/punchbowl/data/tests/test_punch_io.py
+++ b/punchbowl/data/tests/test_punch_io.py
@@ -21,7 +21,7 @@ from punchbowl.data.punch_io import (
     write_ndcube_to_quicklook,
 )
 from punchbowl.data.punchcube import PUNCHCube
-from punchbowl.data.wcs import calculate_pc_matrix
+from punchbowl.data.wcs import calculate_celestial_wcs_from_helio, calculate_pc_matrix
 
 TESTDATA_DIR = os.path.dirname(__file__)
 SAMPLE_FITS_PATH_UNCOMPRESSED = os.path.join(TESTDATA_DIR, "test_data.fits")
@@ -65,7 +65,9 @@ def sample_ndcube():
             meta['CRLT_OBS'] = 1.6391084786225854
             meta['CRLN_OBS'] = 131.07429379735413
             meta['DSUN_OBS'] = 152011862324.1987
-        return PUNCHCube(data=data, uncertainty=uncertainty, wcs=wcs, meta=meta)
+
+        celestial_wcs = calculate_celestial_wcs_from_helio(wcs, date_obs, data.shape)
+        return PUNCHCube(data=data, uncertainty=uncertainty, wcs=wcs, meta=meta, celestial_wcs=celestial_wcs)
     return _sample_ndcube
 
 

--- a/punchbowl/level2/flow.py
+++ b/punchbowl/level2/flow.py
@@ -13,7 +13,7 @@ from punchbowl.level2.finalize import finalize_output
 from punchbowl.level2.merge import merge_many_clear_task, merge_many_polarized_task
 from punchbowl.level2.polarization import resolve_polarization_task
 from punchbowl.level2.preprocess import preprocess_trefoil_inputs
-from punchbowl.level2.resample import find_central_pixel, reproject_many_flow
+from punchbowl.level2.resample import coalign_L1_mzp, find_central_pixel, reproject_many_flow
 from punchbowl.prefect import get_logger, punch_flow
 from punchbowl.util import load_image_task, output_image_task
 
@@ -111,25 +111,80 @@ def level2_core_flow(data_list: list[str] | list[PUNCHCube], # noqa: C901
                         ordered_voters[i] = voter_filenames[j]
             logger.info("Ordered files are "
                         f"{[get_base_file_name(cube) if cube is not None else None for cube in ordered_data_list]}")
-            data_list = [resolve_polarization_task.submit(ordered_data_list[i:i+3])
+
+            # This needs to happen before we shift into a different (upscaled) L1 frame
+            preprocess_trefoil_inputs(ordered_data_list, ordered_mask_list, trim_edges_px, alphas_file)
+
+            # Now we co-align each MZP triplet. The image pointing may drift slowly across the sequence. Each
+            # individual L1 has its pointing determined by the stars, so we can zero out any drift. This ensures than
+            # when we convert the polarization from instrument MZP to solar MZP, the instrument MZP samples are of
+            # the same exact thing on the sky. (This is especially important for stars!)
+            coaligned_ordered_cubes = [None] * len(ordered_data_list)
+            for i in range(0, len(POLARIZED_FILE_ORDER), 3):
+                cubes = ordered_data_list[i:i + 3]
+                if any(c is None for c in cubes):
+                    continue
+                # We reproject the images into the Z frame. The Z image must be reprojected as well, so everyone gets
+                # the same amount of anti-aliasing blur. We reproject into a larger (scaled up) pixel grid,
+                # to minimize the impact this extra round of reprojection has on the blur of the final images. The
+                # co-aligned frame also strips out the distortion table, since that's just extra coordinates work we
+                # don't need.
+                coaligned_ordered_cubes[i:i + 3] = coalign_L1_mzp(cubes, scale_factor=1.4)
+            logger.info("L1s co-aligned")
+
+            data_list = [resolve_polarization_task.submit(coaligned_ordered_cubes[i:i+3])
                          for i in range(0, len(POLARIZED_FILE_ORDER), 3)]
             data_list = [entry.result() for entry in data_list]
             data_list = [j for i in data_list for j in i]
+            logger.info("Polarization resolved")
+
             voter_filenames = ordered_voters
-            image_masks = ordered_mask_list
             # Use the Z state for each file
-            center_inputs = [cube for cube  in ordered_data_list if cube is not None and cube.meta["POLAR"].value == 0]
+            center_inputs = [cube for cube in ordered_data_list if cube is not None and cube.meta["POLAR"].value == 0]
         else:
+            preprocess_trefoil_inputs(data_list, image_masks, trim_edges_px, alphas_file)
             center_inputs = data_list
 
         default_trefoil_wcs, default_trefoil_shape = load_trefoil_wcs()
         trefoil_wcs = trefoil_wcs or default_trefoil_wcs
         trefoil_shape = trefoil_shape or default_trefoil_shape
 
-        preprocess_trefoil_inputs(data_list, image_masks, trim_edges_px, alphas_file)
+        if polarized:
+            # Since we co-aligned the L1 images, they have identical WCSes. That means when we do the reprojection, we
+            # can stack each MZP triplet together so the coordinates work only has to happen once.
+            combined_cubes = []
+            for i in range(0, len(POLARIZED_FILE_ORDER), 3):
+                cubes = data_list[i:i + 3]
+                if any(c is None for c in cubes):
+                    combined_cubes.append(None)
+                    continue
+                data_stack = np.stack([c.data for c in cubes], axis=0)
+                uncert_stack = np.stack([c.uncertainty.array for c in cubes], axis=0)
+                combined_cubes.append(cubes[1].replace(data=data_stack, uncertainty=StdDevUncertainty(uncert_stack)))
 
-        data_list = reproject_many_flow(data_list, trefoil_wcs, trefoil_shape, rolloff_width=rolloff_width,
-                                        rolloff_strength=rolloff_strength)
+            reprojected_stacks = reproject_many_flow(combined_cubes, trefoil_wcs, (3, *trefoil_shape),
+                                                     rolloff_width=rolloff_width,
+                                                     rolloff_strength=rolloff_strength)
+
+            # Now we un-stack each MZP triplet
+            reprojected_cubes = []
+            for i, repro_result in zip(range(0, len(POLARIZED_FILE_ORDER), 3), reprojected_stacks, strict=True):
+                cubes = data_list[i:i + 3]
+                if repro_result is None:
+                    reprojected_cubes.extend([None] * 3)
+                    continue
+                for j in range(len(cubes)):
+                    # reproject_many_flow returns cubes that have the new data and WCS, and the old, unadjusted meta.
+                    # We match that here.
+                    cube = cubes[j].replace(data=repro_result.data[j], uncertainty=repro_result.uncertainty[j],
+                                            wcs=trefoil_wcs)
+                    reprojected_cubes.append(cube)
+            data_list = reprojected_cubes
+        else:
+            data_list = reproject_many_flow(data_list, trefoil_wcs, trefoil_shape, rolloff_width=rolloff_width,
+                                            rolloff_strength=rolloff_strength)
+        logger.info("Cubes reprojected")
+
         data_list = [identify_bright_structures_task(cube, this_voter_filenames)
                      for cube, this_voter_filenames in zip(data_list, voter_filenames, strict=True)]
         merger = merge_many_polarized_task if polarized else merge_many_clear_task

--- a/punchbowl/level2/flow.py
+++ b/punchbowl/level2/flow.py
@@ -83,7 +83,7 @@ def level2_core_flow(data_list: list[str] | list[PUNCHCube], # noqa: C901
     logger = get_logger()
     logger.info("beginning level 2 core flow")
 
-    data_list = [load_image_task(d) if isinstance(d, str) else d for d in data_list]
+    data_list = [load_image_task(d, dtype=np.float32) if isinstance(d, str) else d for d in data_list]
     if image_masks is None:
         image_masks = [None] * len(data_list)
 

--- a/punchbowl/level2/polarization.py
+++ b/punchbowl/level2/polarization.py
@@ -38,10 +38,11 @@ def resolve_polarization(data_list: list[PUNCHCube], outsys: str = "mzpsolar") -
 
     for key in resolved_data_collection:
         # The resolved cube's meta is a "normal" header object, not our NormalizedMetadata, so no .value!
-        input_collection[key].meta["POLARREF"] = resolved_data_collection[key].meta["POLARREF"]
-        resolved_data_collection[key].meta = input_collection[key].meta
-        resolved_data_collection[key].uncertainty = input_collection[key].uncertainty
-        out.append(resolved_data_collection[key])
+        resolved_cube = resolved_data_collection[key]
+        source_cube = input_collection[key]
+        source_cube.meta["POLARREF"] = resolved_cube.meta["POLARREF"]
+        cube = source_cube.replace(data=resolved_cube.data, mask=resolved_cube.mask)
+        out.append(cube)
 
     return out
 

--- a/punchbowl/level2/resample.py
+++ b/punchbowl/level2/resample.py
@@ -6,7 +6,7 @@ from astropy.wcs import WCS
 from scipy.ndimage import distance_transform_edt
 
 from punchbowl.data.punchcube import PUNCHCube
-from punchbowl.data.wcs import calculate_celestial_wcs_from_helio
+from punchbowl.data.wcs import calculate_celestial_wcs_from_helio, calculate_helio_wcs_from_celestial
 from punchbowl.prefect import get_logger, punch_flow, punch_task
 
 
@@ -216,3 +216,46 @@ def find_central_pixel(data_list: list[PUNCHCube | None], trefoil_wcs: WCS) -> l
         # Convert from 0D numpy arrays to Python floats
         centers.append((location[0].item(), location[1].item()))
     return centers
+
+
+def coalign_L1_mzp(mzp_cubes: list[PUNCHCube], scale_factor: float=1) -> list[PUNCHCube]: # noqa: N802
+    """
+    Coalign a set of MZP L1 images into the same exact frame, to account for slight pointing drift.
+
+    The common frame is the frame of the middle of the three images, with the distortion maps removed and (optionally)
+    scaled up by a factor.
+
+    Parameters
+    ----------
+    mzp_cubes : list[PUNCHCube]
+        An L1 MZP triplet (three cubes from the same observatory in the same half of the roll position).
+    scale_factor : float
+        An amount by which to up-scale the common frame, to reduce the blurring effect of this extra round of
+        reprojection.
+
+    Returns
+    -------
+    coaligned_cubes : list[PUNCHCube]
+        The three images in a common frame
+
+    """
+    target_l1_frame = mzp_cubes[1].celestial_wcs.deepcopy()
+    target_l1_frame.cpdis1 = None
+    target_l1_frame.cpdis2 = None
+    target_l1_frame.wcs.cdelt /= scale_factor
+    target_l1_frame.wcs.crpix *= scale_factor
+    target_shape = int(target_l1_frame.array_shape[0] * scale_factor)
+    target_shape = (target_shape, target_shape)
+    target_helio_frame = calculate_helio_wcs_from_celestial(target_l1_frame, mzp_cubes[1].meta.astropy_time,
+                                                            target_shape)
+    coaligned_cubes = []
+    for j in range(3):
+        res = reproject.reproject_adaptive(
+            (np.stack((mzp_cubes[j].data, mzp_cubes[j].uncertainty.array), axis=0),
+             mzp_cubes[j].celestial_wcs),
+            target_l1_frame, target_shape, roundtrip_coords=False, return_footprint=False)
+
+        res = mzp_cubes[j].replace(data=res[0], uncertainty=StdDevUncertainty(res[1]),
+                                   celestial_wcs=target_l1_frame, wcs=target_helio_frame)
+        coaligned_cubes.append(res)
+    return coaligned_cubes

--- a/punchbowl/level2/resample.py
+++ b/punchbowl/level2/resample.py
@@ -250,12 +250,14 @@ def coalign_L1_mzp(mzp_cubes: list[PUNCHCube], scale_factor: float=1) -> list[PU
                                                             target_shape)
     coaligned_cubes = []
     for j in range(3):
-        res = reproject.reproject_adaptive(
+        out_array = np.empty((2, *target_shape), dtype=mzp_cubes[j].data.dtype)
+        reproject.reproject_adaptive(
             (np.stack((mzp_cubes[j].data, mzp_cubes[j].uncertainty.array), axis=0),
              mzp_cubes[j].celestial_wcs),
-            target_l1_frame, target_shape, roundtrip_coords=False, return_footprint=False)
+            target_l1_frame, target_shape,
+            output_array=out_array, roundtrip_coords=False, return_footprint=False)
 
-        res = mzp_cubes[j].replace(data=res[0], uncertainty=StdDevUncertainty(res[1]),
+        res = mzp_cubes[j].replace(data=out_array[0], uncertainty=StdDevUncertainty(out_array[1]),
                                    celestial_wcs=target_l1_frame, wcs=target_helio_frame)
         coaligned_cubes.append(res)
     return coaligned_cubes

--- a/punchbowl/level2/tests/test_flow.py
+++ b/punchbowl/level2/tests/test_flow.py
@@ -52,7 +52,7 @@ def test_ctm_flow_runs_with_filenames(sample_ndcube, tmpdir):
 
 @pytest.mark.parametrize("drop_indices", [[], [1], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
 def test_core_flow_runs_with_objects_and_calibration_files(sample_ndcube, drop_indices, tmpdir):
-    data_list = [sample_ndcube(shape=(10, 10), code=code, level="1")
+    data_list = [sample_ndcube(shape=(100, 100), code=code, level="1")
                  for i, code in enumerate(POLARIZED_FILE_ORDER) if i not in drop_indices]
 
     trefoil_wcs, _ = load_trefoil_wcs()


### PR DESCRIPTION
Closes #1058

Now we co-align MZP triplets before converting the polarization. This is by reprojecting the three images into the same target frame. That frame is the Z frame, but with the distortion maps removed (to reduce the workload for computing both this reprojection and the following L1 -> L2 reprojection). Reprojection always adds a bit of blurriness, so the Z image has to be reprojected into its own frame so it gets the same blurring as M and P. The common L1 frame is also scaled up by 40%, which reduces the amount of extra blurring we get by adding this round of reprojection.

This extra reprojection adds a compute speed penalty, but that's partially mitigated by the fact that our co-aligned L1s are in the exact same frame, so when we do the common-L1 -> L2 reprojection, we can stack the three images and do one reproject call, and the coordinate transformations only have to be computed once (rather than separately for the M, Z and P images).

Here are two before-and-after comparisons. Each is a cutout of an L2 image. The columns are tB, pB, and pB', and the rows are before this PR, with this PR, and the difference. In pB and especially in pB', there are bipoles and negative values wherever there are bright stars in the images, and these unphysical artifacts are reduced with this PR. The tB difference shows the extra blurring due to the extra reprojection (and the difference frames' colorbars are zoomed in 10x), but that blurring isn't visually apparent in the tB panels themselves.

<img width="1920" height="1895" alt="image" src="https://github.com/user-attachments/assets/eee57021-75fd-4186-b493-d9e706488d0c" />
<img width="1920" height="1896" alt="image" src="https://github.com/user-attachments/assets/9eb8e444-fee0-4533-bba8-36ff14fb793c" />
