### PR TITLE
Add AI disclosure to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 - [ ] implement new feature or fix bug
 - [ ] include tests
-- [ ] update associated documentation website entry
+- [ ] update associated documentation entry
 
 ## Test plan
 
@@ -21,3 +21,7 @@
 ## Related Issues
 
 *Link the issues related to this PR.*
+
+## AI Usage
+
+*State how AI was used in this PR.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,6 @@
 
 *Link the issues related to this PR.*
 
-## AI Usage
+## AI usage
 
 *State how AI was used in this PR.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 
 *Document any breaking changes from this PR.*
 
-## Related Issues
+## Related issues
 
 *Link the issues related to this PR.*
 


### PR DESCRIPTION
## PR summary

This PR adds an AI disclosure to PR templates. This conforms with our request in our AI policy https://github.com/punch-mission/punch-mission/blob/main/contributing.md#what-about-ai-contributions

## Todos

None

## Test plan

None needed

## Breaking changes

None

## Related Issues

None