### PR TITLE
Add helioviewer tag to jp2 files.

### DIFF
--- a/changelog/1109.bugfix.rst
+++ b/changelog/1109.bugfix.rst
@@ -1,0 +1,1 @@
+Added the helioviewer tag to the JPEG2000 quicklook files. This will allow the image scaling of PUNCH data in Helioviewer to be correct.

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -72,15 +72,14 @@ class DefaultFormatter(string.Formatter):
 
 def _meta_for_helioviewer() -> et.Element:
     """Generate a helioviewer XML Tree so JPEG2000 files render properly."""
-    now_no_us = str(datetime.now(UTC).replace(microsecond=0))
-    hv = et.Element("helioviewer")
-    et.SubElement(hv,"HV_ROTATION").text = "0.0"
-    et.SubElement(hv,"HV_COMMENT").text = \
-    f"""JP2 file created at Southwest Research Institute using punchbowl's write_ndcube_to_quicklook at {now_no_us}.
-    Contact punch_soc@swri.org for more details regarding this JP2 file.
-    """
-    et.SubElement(hv,"HV_SUPPORTED").text = "TRUE"
-    return hv
+    now_no_microsecs = str(datetime.now(UTC).replace(microsecond=0))
+    helioviewer_element = et.Element("helioviewer")
+    et.SubElement(helioviewer_element,"HV_ROTATION").text = "0.0"
+    et.SubElement(helioviewer_element,"HV_COMMENT").text = \
+    f"""JP2 file created at Southwest Research Institute using punchbowl's write_ndcube_to_quicklook at {now_no_microsecs}.
+    Contact punch_soc@swri.org for more details regarding this JP2 file.""" # noqa: E501
+    et.SubElement(helioviewer_element,"HV_SUPPORTED").text = "TRUE"
+    return helioviewer_element
 
 
 def _header_to_xml(header: Header) -> et.Element:

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -11,6 +11,7 @@ import multiprocessing as mp
 from copy import deepcopy
 from typing import Any
 from pathlib import Path
+from datetime import UTC, datetime
 from itertools import repeat
 from collections.abc import Sequence
 from concurrent.futures import ProcessPoolExecutor
@@ -69,6 +70,18 @@ class DefaultFormatter(string.Formatter):
         except (KeyError, AttributeError, IndexError):
             return "{" + field_name + "}", ()
 
+def _meta_for_helioviewer() -> et.Element:
+    """Generate a helioviewer XML Tree so JPEG2000 files render properly."""
+    now_no_us = str(datetime.now(UTC).replace(microsecond=0))
+    hv = et.Element("helioviewer")
+    et.SubElement(hv,"HV_ROTATION").text = "0.0"
+    et.SubElement(hv,"HV_COMMENT").text = \
+    f"""JP2 file created at Southwest Research Institute using punchbowl's write_ndcube_to_quicklook at {now_no_us}.
+    Contact punch_soc@swri.org for more details regarding this JP2 file.
+    """
+    et.SubElement(hv,"HV_SUPPORTED").text = "TRUE"
+    return hv
+
 
 def _header_to_xml(header: Header) -> et.Element:
     """
@@ -98,6 +111,8 @@ def _generate_jp2_xmlbox(header: Header) -> jp2box.XMLBox:
     header_xml = _header_to_xml(header)
     meta = et.Element("meta")
     meta.append(header_xml)
+    helioviewer_xml = _meta_for_helioviewer()
+    meta.append(helioviewer_xml)
     tree = et.ElementTree(meta)
     return jp2box.XMLBox(xml=tree)
 

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -70,7 +70,7 @@ class DefaultFormatter(string.Formatter):
         except (KeyError, AttributeError, IndexError):
             return "{" + field_name + "}", ()
 
-def _meta_for_helioviewer() -> et.Element:
+def _create_meta_for_helioviewer() -> et.Element:
     """Generate a helioviewer XML Tree so JPEG2000 files render properly."""
     now_no_microsecs = str(datetime.now(UTC).replace(microsecond=0))
     helioviewer_element = et.Element("helioviewer")
@@ -110,8 +110,7 @@ def _generate_jp2_xmlbox(header: Header) -> jp2box.XMLBox:
     header_xml = _header_to_xml(header)
     meta = et.Element("meta")
     meta.append(header_xml)
-    helioviewer_xml = _meta_for_helioviewer()
-    meta.append(helioviewer_xml)
+    meta.append(_create_meta_for_helioviewer())
     tree = et.ElementTree(meta)
     return jp2box.XMLBox(xml=tree)
 

--- a/punchbowl/data/tests/test_punch_io.py
+++ b/punchbowl/data/tests/test_punch_io.py
@@ -1,7 +1,6 @@
 import os
 from datetime import UTC, datetime
 
-import glymur
 import lxml.etree as et
 import numpy as np
 import pytest
@@ -9,6 +8,7 @@ from astropy.io import fits
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs import WCS, DistortionLookupTable
 from astropy.wcs.utils import add_stokes_axis_to_wcs
+from glymur import Jp2kr, jp2box
 
 from punchbowl.data.meta import NormalizedMetadata
 from punchbowl.data.punch_io import (
@@ -105,26 +105,31 @@ def test_write_data_jp2(sample_ndcube, tmpdir):
 
     #now check that the written file has the helioviewer tag.
     #the tag should be in the jp2 xml meta box.
-    jp2_read_in = glymur.Jp2kr(test_path)
-    xml_box = next((box for box in jp2_read_in.box if isinstance(box, glymur.jp2box.XMLBox)),None)
-    has_fits_top_level = False
-    has_hv_top_level = False
+    #open the JP2 file
+    jp2_read_in = Jp2kr(test_path)
+    #find the XML box, assuming there's only one
+    xml_box = next((box for box in jp2_read_in.box if isinstance(box, jp2box.XMLBox)), None)
+
     if xml_box is not None:
-       raw_xml_bytes = et.tostring(xml_box.xml)
-       root = et.fromstring(raw_xml_bytes)
-       meta_elements = root.xpath("//*[local-name()='meta']")
-       meta_box = meta_elements[0]
-       for child in meta_box.iterchildren():
-           local_tag = et.QName(child).localname
-           if local_tag == 'fits':
-               has_fits_top_level = True
-           if local_tag == 'helioviewer':
-               has_hv_top_level = True
-           if has_fits_top_level and has_hv_top_level:
-               break
-           1
-    assert has_fits_top_level==True
-    assert has_hv_top_level==True
+       #xml_box.xml is an lxml ElementTree or Element
+       xml_root = xml_box.xml
+
+       #If an ElementTree, get the root element
+       if isinstance(xml_root, et._ElementTree):
+           xml_root = xml_root.getroot()
+
+       #now xml_root is the "meta" tag
+       has_fits = xml_root.find('.//fits') is not None
+       hv_element = xml_root.find('.//helioviewer')
+       if hv_element is not None:
+           has_hv = True
+           has_hv_rotation = hv_element.find('.//HV_ROTATION') is not None
+           has_hv_comment = hv_element.find('.//HV_COMMENT') is not None
+
+    assert has_fits==True
+    assert has_hv==True
+    assert has_hv_rotation==True
+    assert has_hv_comment==True
 
 def test_write_jpeg(sample_ndcube, tmpdir):
     from punchbowl.data.sample import PUNCH_PAM

--- a/punchbowl/data/tests/test_punch_io.py
+++ b/punchbowl/data/tests/test_punch_io.py
@@ -1,6 +1,8 @@
 import os
 from datetime import UTC, datetime
 
+import glymur
+import lxml.etree as et
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -100,6 +102,29 @@ def test_write_data_jp2(sample_ndcube, tmpdir):
     test_path = os.path.join(tmpdir, "test.jp2")
     write_ndcube_to_quicklook(cube, test_path)
     assert os.path.isfile(test_path)
+
+    #now check that the written file has the helioviewer tag.
+    #the tag should be in the jp2 xml meta box.
+    jp2_read_in = glymur.Jp2kr(test_path)
+    xml_box = next((box for box in jp2_read_in.box if isinstance(box, glymur.jp2box.XMLBox)),None)
+    has_fits_top_level = False
+    has_hv_top_level = False
+    if xml_box is not None:
+       raw_xml_bytes = et.tostring(xml_box.xml)
+       root = et.fromstring(raw_xml_bytes)
+       meta_elements = root.xpath("//*[local-name()='meta']")
+       meta_box = meta_elements[0]
+       for child in meta_box.iterchildren():
+           local_tag = et.QName(child).localname
+           if local_tag == 'fits':
+               has_fits_top_level = True
+           if local_tag == 'helioviewer':
+               has_hv_top_level = True
+           if has_fits_top_level and has_hv_top_level:
+               break
+           1
+    assert has_fits_top_level==True
+    assert has_hv_top_level==True
 
 def test_write_jpeg(sample_ndcube, tmpdir):
     from punchbowl.data.sample import PUNCH_PAM


### PR DESCRIPTION
## PR summary

This adds the `<helioviewer>` tag to the JPEG2000 quicklook files. This will allow the image scaling of PUNCH data in Helioviewer to be correct. This also adds some tests that the `<fits>` and `<helioviewer>` tags are in the jp2 xml metadata.

## Todos

- [ ] get confirmation from helioviewer team that the current format is acceptable.

## Test plan

Now after writing one of the test .jp2 files, we read it back in and make sure that the `<fits>` and `<helioviewer>` tags are present. No check is made that any of the metadata is actually correct, since only a blank test image is created.

## Breaking changes

None

## Related issues

Closes #935.

## AI usage

AI was used to write the new content in the test `test_write_data_jp2` that reads in the generated .jp2 file and parses the XML tree to check for the `<fits>` and `<helioviewer>` keywords.
