### PR TITLE
Flips starfield axis during subtraction

### DIFF
--- a/changelog/1134.bugfix.rst
+++ b/changelog/1134.bugfix.rst
@@ -1,1 +1,1 @@
-Corrects a bug with starfield model cdelt during subtraction.
+Corrects a bug with starfield model subtraction where the RA-axis cdelt was being accidentally sign flipped twice.

--- a/changelog/1134.bugfix.rst
+++ b/changelog/1134.bugfix.rst
@@ -1,0 +1,1 @@
+Corrects a bug with starfield model cdelt during subtraction.

--- a/punchbowl/level3/stellar.py
+++ b/punchbowl/level3/stellar.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 from math import floor
 from datetime import UTC, datetime
@@ -393,17 +394,17 @@ def subtract_starfield_background_task(data_object: PUNCHCube,
 
         wcs_celestial_before = star_datacube_before.celestial_wcs
         if wcs_celestial_before.naxis == 3:
-            wcs_celestial_before_short = wcs_celestial_before.dropaxis(2)
+            wcs_celestial_before_short = copy.deepcopy(wcs_celestial_before.dropaxis(2))
         else:
-            wcs_celestial_before_short = wcs_celestial_before
+            wcs_celestial_before_short = copy.deepcopy(wcs_celestial_before)
         wcs_celestial_before_short.wcs.cdelt[0] *= -1
         wcs_celestial_before.wcs.cdelt[0] = wcs_celestial_before.wcs.cdelt[0] * -1
 
         wcs_celestial_after = star_datacube_after.celestial_wcs
         if  wcs_celestial_after.naxis == 3:
-            wcs_celestial_after_short = wcs_celestial_after.dropaxis(2)
+            wcs_celestial_after_short = copy.deepcopy(wcs_celestial_after.dropaxis(2))
         else:
-            wcs_celestial_after_short = wcs_celestial_after
+            wcs_celestial_after_short = copy.deepcopy(wcs_celestial_after)
         wcs_celestial_after_short.wcs.cdelt[0] *= -1
         wcs_celestial_after.wcs.cdelt[0] = wcs_celestial_after.wcs.cdelt[0] * -1
 


### PR DESCRIPTION
## PR summary

A errant flip was occurring in one of the starfield model axes during the subtraction process, when determining a union WCS encompassing models. The WCS does need to be flipped along the RA axis to account for this factor of -1 with the cdelt. However, the code was making a reference to the WCS, which resulted in the flip being undone.

This corrects that by making a deepcopy of the model WCS to avoid flipping a flip.

## Todos

None

## Test plan

See below example plots testing with v0l data on punch190.

## Breaking changes

None

## Related issues

None

## AI usage

None.
