### PR TITLE
#1001 put nfi back into mosiacs

### DIFF
--- a/changelog/1135.feature.rst
+++ b/changelog/1135.feature.rst
@@ -1,0 +1,1 @@
+Undo all code disablements of NFI, to now put NFI back into the mosaics.

--- a/punchbowl/auto/flows/level1.py
+++ b/punchbowl/auto/flows/level1.py
@@ -270,7 +270,7 @@ def get_psf_model_paths(level0_files, pipeline_config: dict, session=None):
               .order_by(File.file_version.desc(), File.date_obs.desc()).all())
     results = []
     for l0_file in level0_files:
-        
+
         target_type = PSF_MODEL_CORRESPONDING_TYPES[l0_file.file_type[1]]
         # We want to pick the latest model that's before the observation, so we go backwards in time, past any
         # later-in-time models, until we hit the first model that's before the observation.
@@ -290,7 +290,7 @@ def get_psf_model_paths(level0_files, pipeline_config: dict, session=None):
 
 def get_psf_model_path(level0_file, pipeline_config: dict, session=None, reference_time=None) -> str:
     psf_model_type = PSF_MODEL_CORRESPONDING_TYPES[level0_file.file_type[1]]
-    
+
     best_model = (session.query(File)
                   .filter(File.file_type == psf_model_type)
                   .filter(File.observatory == level0_file.observatory)
@@ -572,7 +572,7 @@ def level1_early_call_data_processor(call_data: dict, pipeline_config, session=N
                 "second_vignetting_function_path", "mask_path", "distortion_path"]:
         call_data[key] = file_name_to_full_path(call_data[key], pipeline_config["root"])
 
-    
+
     call_data["psf_model_path"] = file_name_to_full_path(call_data["psf_model_path"], pipeline_config["root"])
     call_data["psf_model_path"] = cache_layer.psf.wrap_if_appropriate(call_data["psf_model_path"])
 

--- a/punchbowl/auto/flows/level1.py
+++ b/punchbowl/auto/flows/level1.py
@@ -270,10 +270,7 @@ def get_psf_model_paths(level0_files, pipeline_config: dict, session=None):
               .order_by(File.file_version.desc(), File.date_obs.desc()).all())
     results = []
     for l0_file in level0_files:
-        # TODO - Turn this back on once fine tuned for NFI
-        if l0_file.observatory == "4":
-            results.append("")
-            continue
+        
         target_type = PSF_MODEL_CORRESPONDING_TYPES[l0_file.file_type[1]]
         # We want to pick the latest model that's before the observation, so we go backwards in time, past any
         # later-in-time models, until we hit the first model that's before the observation.
@@ -293,9 +290,7 @@ def get_psf_model_paths(level0_files, pipeline_config: dict, session=None):
 
 def get_psf_model_path(level0_file, pipeline_config: dict, session=None, reference_time=None) -> str:
     psf_model_type = PSF_MODEL_CORRESPONDING_TYPES[level0_file.file_type[1]]
-    # TODO - Turn this back on once fine tuned for NFI
-    if level0_file.observatory == "4":
-        return ""
+    
     best_model = (session.query(File)
                   .filter(File.file_type == psf_model_type)
                   .filter(File.observatory == level0_file.observatory)

--- a/punchbowl/auto/flows/level1.py
+++ b/punchbowl/auto/flows/level1.py
@@ -572,12 +572,9 @@ def level1_early_call_data_processor(call_data: dict, pipeline_config, session=N
                 "second_vignetting_function_path", "mask_path", "distortion_path"]:
         call_data[key] = file_name_to_full_path(call_data[key], pipeline_config["root"])
 
-    # TODO: this is a hack to skip NFI PSF. Remove!
-    if call_data["psf_model_path"] == "":
-        call_data["psf_model_path"] = None
-    else:
-        call_data["psf_model_path"] = file_name_to_full_path(call_data["psf_model_path"], pipeline_config["root"])
-        call_data["psf_model_path"] = cache_layer.psf.wrap_if_appropriate(call_data["psf_model_path"])
+    
+    call_data["psf_model_path"] = file_name_to_full_path(call_data["psf_model_path"], pipeline_config["root"])
+    call_data["psf_model_path"] = cache_layer.psf.wrap_if_appropriate(call_data["psf_model_path"])
 
     call_data["quartic_coefficient_path"] = cache_layer.quartic_coefficients.wrap_if_appropriate(
         call_data["quartic_coefficient_path"])

--- a/punchbowl/auto/flows/level2.py
+++ b/punchbowl/auto/flows/level2.py
@@ -34,8 +34,7 @@ def _level2_query_ready_files(session, polarized: bool, pipeline_config: dict, m
     logger = get_logger()
     all_ready_files = (session.query(File).filter(File.state == "created")
                        .filter(File.level == "1")
-                        # TODO: This line temporarily excludes NFI
-                       .filter(File.observatory.in_(["1", "2", "3"]))
+                       .filter(File.observatory.in_(["1", "2", "3", "4"]))
                        .filter(File.file_type.in_(
                             SCIENCE_POLARIZED_LEVEL1_TYPES if polarized else SCIENCE_CLEAR_LEVEL1_TYPES))
                        # The ascending sort order is expected by the file grouping code
@@ -69,9 +68,7 @@ def _level2_query_ready_files(session, polarized: bool, pipeline_config: dict, m
     for group in grouped_files:
         if len(grouped_ready_files) >= max_n:
             break
-        # TODO: This line temporarily excludes NFI
-        # group_is_complete = len(group) == (12 if polarized else 4)
-        group_is_complete = len(group) == (9 if polarized else 3)
+        group_is_complete = len(group) == (12 if polarized else 4)
         if group_is_complete:
             grouped_ready_files.append(group)
             continue
@@ -114,8 +111,7 @@ def _level2_query_ready_files(session, polarized: bool, pipeline_config: dict, m
         # Grab all the L0s that produce inputs for this trefoil
         expected_inputs = (session.query(File)
                                   .filter(File.level == "0")
-                                  # TODO: This line temporarily excludes NFI
-                                  .filter(File.observatory.in_(["1", "2", "3"]))
+                                  .filter(File.observatory.in_(["1", "2", "3", "4"]))
                                   .filter(File.file_type.in_(search_types))
                                   .filter(File.date_obs > center - search_width)
                                   .filter(File.date_obs < center + search_width)

--- a/punchbowl/auto/flows/level2.py
+++ b/punchbowl/auto/flows/level2.py
@@ -34,7 +34,6 @@ def _level2_query_ready_files(session, polarized: bool, pipeline_config: dict, m
     logger = get_logger()
     all_ready_files = (session.query(File).filter(File.state == "created")
                        .filter(File.level == "1")
-                       .filter(File.observatory.in_(["1", "2", "3", "4"]))
                        .filter(File.file_type.in_(
                             SCIENCE_POLARIZED_LEVEL1_TYPES if polarized else SCIENCE_CLEAR_LEVEL1_TYPES))
                        # The ascending sort order is expected by the file grouping code

--- a/punchbowl/auto/flows/level3.py
+++ b/punchbowl/auto/flows/level3.py
@@ -291,8 +291,7 @@ def level3_CIM_PIM_query_ready_files(session, pipeline_config: dict, reference_t
     target_type = 'XP' if polarized else 'XR'
     all_ready_files = (session.query(File).filter(File.state == "created")
                        .filter(File.level == "2")
-                       # TODO: This line temporarily excludes NFI
-                       .filter(File.observatory.in_(["1", "2", "3"]))
+                       .filter(File.observatory.in_(["1", "2", "3", "4"]))
                        .filter(File.file_type == target_type)
                        # The ascending sort order is expected by the file grouping code
                        .order_by(File.date_obs.asc()).all())

--- a/punchbowl/auto/flows/tests/test_level2.py
+++ b/punchbowl/auto/flows/tests/test_level2.py
@@ -176,10 +176,6 @@ def test_level2_query_ready_files():
                         expected_groups[expected_output_group].extend(triplet)
                     expected_output_group = (expected_output_group + 1) % 3
 
-                # TODO: we're temporarily excluding NFI in the L2 flows (remove these two lines when that changes)
-                input_files = [f for f in input_files if f.observatory != '4']
-                expected_groups = [[f for f in g if f.observatory != '4'] for g in expected_groups]
-
                 expected_groups = [set(f.file_id for f in g) for g in expected_groups if len(g)]
                 output_groups = group_l2_inputs(input_files)
                 output_groups = [set(f.file_id for f in g) for g in output_groups]


### PR DESCRIPTION
## PR summary

*What does this PR introduce?*

This PR is supposed to undo all the commented out lines that were put in place to ignore NFI in the pipeline until the dynamic stray light could be dealt with. Now that we have the PCA method to initially release some visually pleasing NFI images, we want to incorporate those results into the mosaics.

## Todos

*Please list tasks to complete this PR.*

- [ ] Find and appropriately modify the todos that used to comment out NFI 
- [ ] "Test" that somehow nothing in the pipeline is critically broken from the changes made

## Test plan

*How does this PR verify the code works correctly?*

TBD...

## Breaking changes

*Document any breaking changes from this PR.*

## Related issues

*Link the issues related to this PR.*

This is the main task of ticket #1001 

## AI usage

*State how AI was used in this PR.*
