### PR TITLE
Fix NFI DSATVAL

### DIFF
--- a/changelog/1153.bugfix.rst
+++ b/changelog/1153.bugfix.rst
@@ -1,0 +1,1 @@
+Fix DSATVAL calculation to set NFI DSATVAL to 1254, but keep WFI DSATVAL at 1023.

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -818,14 +818,14 @@ def get_metadata(first_image_packet,
     if fits_info["ISSQRT"] == 0:
         fits_info["BUNIT"] = "DN"
         fits_info["COMPBITS"] = fits_info["RAWBITS"]
-        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "RAWBITS") because NFI doesn't use 
+        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "RAWBITS") because NFI doesn't use
         # the entire 19 bit dynamic range
         fits_info["DSATVAL"] = (2**16 - 1) * fits_info["IMGCOUNT"]
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, DN values in camera coordinates"
     else:
         fits_info["BUNIT"] = "sqrt(DN)"
         fits_info["COMPBITS"] = round((fits_info["RAWBITS"] + int(np.log2(fits_info["SCALE"]))) / 2, 2)
-        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "COMPBITS") because NFI doesn't use 
+        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "COMPBITS") because NFI doesn't use
         # the entire 11 bit dynamic range
         fits_info["DSATVAL"] = np.floor(np.sqrt((2**16 - 1) * fits_info["SCALE"] * fits_info["IMGCOUNT"]))
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, square-root encoded DN values in camera coordinates"

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -818,14 +818,16 @@ def get_metadata(first_image_packet,
     if fits_info["ISSQRT"] == 0:
         fits_info["BUNIT"] = "DN"
         fits_info["COMPBITS"] = fits_info["RAWBITS"]
-        fits_info["DSATVAL"] = 2**fits_info["RAWBITS"] - 1
+        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "RAWBITS") because NFI doesn't use 
+        # the entire 19 bit dynamic range
+        fits_info["DSATVAL"] = (2**16 - 1) * fits_info["IMGCOUNT"]
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, DN values in camera coordinates"
     else:
         fits_info["BUNIT"] = "sqrt(DN)"
         fits_info["COMPBITS"] = round((fits_info["RAWBITS"] + int(np.log2(fits_info["SCALE"]))) / 2, 2)
-        # NOTE: The hardcoded value in the next line that doesn't use the RAWBITS or COMPBITS specifically associated with NFI vs. WFI
-        # but provides a quick fix that gives the DSATVAL we want for each instrument type
-        fits_info["DSATVAL"] = np.floor(np.sqrt((2**16-1) * fits_info["SCALE"] * fits_info["IMGCOUNT"]))
+        # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "COMPBITS") because NFI doesn't use 
+        # the entire 11 bit dynamic range
+        fits_info["DSATVAL"] = np.floor(np.sqrt((2**16 - 1) * fits_info["SCALE"] * fits_info["IMGCOUNT"]))
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, square-root encoded DN values in camera coordinates"
 
     fits_info |= organize_gain_info(spacecraft_id)

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -810,7 +810,7 @@ def get_metadata(first_image_packet,
         fits_info |= organize_lz_fits_keywords(best_lz_db, best_lz)
 
     fits_info |= organize_compression_and_acquisition_settings(compression_settings, acquisition_settings)
-    if spacecraft_id == 0x2F:
+    if spacecraft_id == 0x2F:   # if NFI
         fits_info["RAWBITS"] = 19
     else:
         fits_info["RAWBITS"] = 16
@@ -823,7 +823,9 @@ def get_metadata(first_image_packet,
     else:
         fits_info["BUNIT"] = "sqrt(DN)"
         fits_info["COMPBITS"] = round((fits_info["RAWBITS"] + int(np.log2(fits_info["SCALE"]))) / 2, 2)
-        fits_info["DSATVAL"] = 2**fits_info["COMPBITS"] - 1
+        # NOTE: The hardcoded value in the next line that doesn't use the RAWBITS or COMPBITS specifically associated with NFI vs. WFI
+        # but provides a quick fix that gives the DSATVAL we want for each instrument type
+        fits_info["DSATVAL"] = np.floor(np.sqrt((2**16-1) * fits_info["SCALE"] * fits_info["IMGCOUNT"]))
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, square-root encoded DN values in camera coordinates"
 
     fits_info |= organize_gain_info(spacecraft_id)

--- a/punchbowl/auto/flows/level0.py
+++ b/punchbowl/auto/flows/level0.py
@@ -827,7 +827,7 @@ def get_metadata(first_image_packet,
         fits_info["COMPBITS"] = round((fits_info["RAWBITS"] + int(np.log2(fits_info["SCALE"]))) / 2, 2)
         # NOTE: 2**16 is used for both NFI and WFI (instead of using respective "COMPBITS") because NFI doesn't use
         # the entire 11 bit dynamic range
-        fits_info["DSATVAL"] = np.floor(np.sqrt((2**16 - 1) * fits_info["SCALE"] * fits_info["IMGCOUNT"]))
+        fits_info["DSATVAL"] = np.floor(np.sqrt((2**16 - 1) * fits_info["IMGCOUNT"] * fits_info["SCALE"]))
         fits_info["DESCRPTN"] = "PUNCH Level-0 data, square-root encoded DN values in camera coordinates"
 
     fits_info |= organize_gain_info(spacecraft_id)


### PR DESCRIPTION
## PR summary
Adds a fix to ensure that DSATVAL is set to correct value such that NFI (and WFI) data are getting flagged as saturated at the correct values. 

## Todos
- [X] Add fix to calculate DSATVAL correctly (for both NFI and WFI)
- [ ] Test the fix?

## Test plan

(Jasmine's 8/28 note)
Challenges remain to test this change directly without having TLM packet files to work with directly to make level0 files.

But a possible alternative test is to take an already made level0 file to run through a level1 flow test, and manually changing the DSATVAL of the test level0 file to make sure that it can properly pass a level1 flow test and creates a level1 file.

## Breaking changes

Mayhaps?

## Related issues
This PR is intended to close issue #1115 

Just a note: This issue was directly addressing the problem where NFI wasn't getting properly flagged as saturated, but the code change required to be mindful of ensuring we don't change the DSATVAL for WFI data (as those were getting flagged correctly), but calculating and setting the DSATVAL for both NFI and WFI was done on the same single line of code.

## AI usage

No AI was used.