### PR TITLE
Add robots=off to wget command

### DIFF
--- a/changelog/1155.bugfix.rst
+++ b/changelog/1155.bugfix.rst
@@ -1,0 +1,1 @@
+Add robots=off to wget command as part of recent umbra.nascom.nasa.gov permissions updates.

--- a/docs/data/access.rst
+++ b/docs/data/access.rst
@@ -31,7 +31,7 @@ If that example is not working properly, you can also pull data directly from th
 
 .. code-block:: bash
 
-    wget -r -l1 --no-parent --no-directories -A "PUNCH_L3_CAM_20250921*_v0k.fits" -R "*.html*,index*,*tmp*" https://umbra.nascom.nasa.gov/punch/3/CAM/2025/09/21/
+    wget -e robots=off -r -l1 --no-parent --no-directories -A "PUNCH_L3_CAM_20250921*_v0k.fits" -R "*.html*,index*,*tmp*" https://umbra.nascom.nasa.gov/punch/3/CAM/2025/09/21/
 
 The above example would pull data for the L3_CAM products on 2025-09-21.
 Change the path and date according to what product you wish to download.


### PR DESCRIPTION
Simple fix to address that [umbra.nascom.nasa.gov](http://umbra.nascom.nasa.gov/) has a more restrictive robots.txt these days, so real data requests have to include the robots=off flag.
