### PR TITLE
Fix #936 by clipping to 1 instead of 0 for transparency

### DIFF
--- a/changelog/1159.bugfix.rst
+++ b/changelog/1159.bugfix.rst
@@ -1,0 +1,1 @@
+We were previously clipping all negative values to 0. This led to negative values becoming transparent in JHelioviewer. This fixes that clipping bug by clipping to 1 instead.

--- a/punchbowl/data/punch_io.py
+++ b/punchbowl/data/punch_io.py
@@ -207,12 +207,15 @@ def write_ndcube_to_quicklook(cube: PUNCHCube, # noqa: C901
         image *= radial_mask
 
     if color:
+        # deprecation: this RGBA is not really used anymore because JHelioviewer wants greyscale images
         mode = "RGBA"
         scaled_arr = (cmap_punch(norm(np.flipud(image))) * 255).astype(np.uint8)
         fill_value = (255, 255, 255)
     else:
         mode = "L"
-        scaled_arr = (np.clip(norm(np.flipud(image)), 0, 1) * 255).astype(np.uint8)
+        zero_mask = (np.flipud(image) == 0)
+        scaled_arr = (np.clip(norm(np.flipud(image)) * 255, 1, 255)).astype(np.uint8)
+        scaled_arr[zero_mask] = 0
         fill_value = 255
 
     pil_image = Image.fromarray(scaled_arr, mode=mode)


### PR DESCRIPTION
We were previously clipping all negative values to 0. This led to negative values becoming transparent in JHelioviewer. This fixes that. 