### PR TITLE
Update the PFWSTAT comment in the omniheader to include a stale flag

### DIFF
--- a/changelog/1170.feature.rst
+++ b/changelog/1170.feature.rst
@@ -1,1 +1,0 @@
-For science images, use the timestamp of the image to set to polarization state of the image. Previously the PFW packet was used even if it was stale, producing erroneously-labelled images.

--- a/changelog/1172.feature.rst
+++ b/changelog/1172.feature.rst
@@ -1,0 +1,1 @@
+For science images, use the timestamp of the image to set to polarization state of the image. Previously the PFW packet was used even if it was stale, producing erroneously-labelled images. The PFWSTAT header value now reads -1 if the PFW packet is stale.

--- a/punchbowl/data/data/omniheader.csv
+++ b/punchbowl/data/data/omniheader.csv
@@ -210,7 +210,7 @@ SECTION,TYPE,KEYWORD,VALUE,COMMENT,DATATYPE,NULLABLE,MUTABLE,DEFAULT
 13,keyword,RBANDS,,Indices of radial bands to visualize,str,TRUE,TRUE,
 14,section,COMMENT,Polarizing Filter Wheel,,str,TRUE,TRUE,Polarizing Filter Wheel
 14,keyword,PFWTIME,,PFW packet timestamp,str,TRUE,TRUE,
-14,keyword,PFWSTAT,,"Current PFW Status (0 - no error, else error)",int,TRUE,TRUE,
+14,keyword,PFWSTAT,,"PFW Status (0=no error, -1=stale, else error)",int,TRUE,TRUE,
 14,keyword,STEPCALC,,Calculated step (0-1199),int,TRUE,TRUE,
 14,keyword,CMDSTEPS,,Commanded number of steps (1-1199),int,TRUE,TRUE,
 14,keyword,HOMEOVRD,,HOME Position OVERRIDE,int,TRUE,TRUE,


### PR DESCRIPTION
## PR summary

Added info to the PFWSTAT comment that "-1" values mean the PFW packet is stale.

Renamed 1170 changelog file to 1172 (typo in original filename).

Added comment to that changelog for this PR.

## Todos

None

## Test plan

Check while reprocessing level-0 files for v0m.

## Breaking changes

None

## Related issues

#1149 

## AI usage

None
